### PR TITLE
NBO base

### DIFF
--- a/nbo-base.owl
+++ b/nbo-base.owl
@@ -1,0 +1,17204 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="urn:absolute:/nbo-base.owl#"
+     xml:base="urn:absolute:/nbo-base.owl"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:nbo="http://purl.obolibrary.org/obo/nbo.owl#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <owl:Ontology rdf:about="urn:absolute:/nbo-base.owl">
+        <owl:versionIRI rdf:resource="urn:absolute:/releases//nbo-base.owl"/>
+        <oboInOwl:remark rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2018-05-11</oboInOwl:remark>
+        <oboInOwl:treat-xrefs-as-equivalent rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO</oboInOwl:treat-xrefs-as-equivalent>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/created_by -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/created_by"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/namespace -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/namespace"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/synonymtype -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/synonymtype"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo.owl#IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/nbo.owl#IAO_0000115"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo.owl#created_by -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/nbo.owl#created_by"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo.owl#namespace -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/nbo.owl#namespace"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo.owl#synonymtype -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/nbo.owl#synonymtype"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/date -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasAlternativeId -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasExactSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#note -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#note"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#xref -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#xref"/>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
+    
+
+
+    <!-- http://www.w3.org/2002/07/owl#deprecated -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#deprecated"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_00000050 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_00000050"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000050 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000050"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000056 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000056"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/RO_0002211 -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002211"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/inheres_in -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/inheres_in">
+        <rdfs:label xml:lang="en">inheres_in</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/chebi#has_role -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/chebi#has_role"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo#by_means -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/nbo#by_means">
+        <rdfs:label xml:lang="en">by_means</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo#has-input -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/nbo#has-input">
+        <rdfs:label xml:lang="en">has-input</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo#has_participant -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/nbo#has_participant">
+        <rdfs:label xml:lang="en">has_participant</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo#in_response_to -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/nbo#in_response_to">
+        <rdfs:label xml:lang="en">in_response_to</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo#is_about -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/nbo#is_about">
+        <rdfs:label xml:lang="en">is_about</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo#qualifier -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/nbo#qualifier">
+        <rdfs:label xml:lang="en">qualifier</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/pato#towards -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/pato#towards"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/uberon#has_quality -->
+
+    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_15377 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15377">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37176"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_52625"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_15734 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15734">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_16236 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_16236">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23982"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50584"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_17303 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_17303">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25418"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38164"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_18723 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_18723">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26416"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26456"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_46775"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_22315 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_22315">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_23367 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_23888 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23888">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_52217"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_23982 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_23982">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_15734"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_24432 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24432">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50906"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_24532 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_24651 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24651">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25806"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33608"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_24835 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24835">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23367"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_24921 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_24921">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22315"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_25418 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25418">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24921"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_25693 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_2571 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_2571">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_25806 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25806"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_26416 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26416">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22315"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_26421"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_26421 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26421">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_26456 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_26456">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22315"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38260"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_27171 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_27958 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_27958">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33308"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37332"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_30879 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_30879"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_32111 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_32111">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_55505"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33232 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33232"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33242 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33242"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33290 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33290">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_52211"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33304 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33304"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33308 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33308">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35701"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36586"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33608 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33608"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33671 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33671"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33692 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33692">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33608"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37577"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33693 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33693">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36902"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_35352 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35352"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_35701 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35701">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_50860"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_35703 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_35703">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24432"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_36586 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36586">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36587"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_36587 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36587"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_36902 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36902">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33242"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33304"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_36963 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_36963"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_37176 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37176">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33692"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_37332 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37332">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_22315"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38295"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_37577 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37577"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_37947 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_37947">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38106"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_38101 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_38106 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38106"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_38164 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38164">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38166"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_38166 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38166">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24532"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33671"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_38260 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25693"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_38295 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38295">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27171"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38101"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_38867 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_38867">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_23888"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_46775 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_46775">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38260"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_50584 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50584">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_2571"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_50860 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50860"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_50906 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_50906"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_52211 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_52211">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24432"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_52217 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_52217">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33232"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_52625 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_52625">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24651"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_24835"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_55505 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_55505">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_37947"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0001101 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0001101"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0002118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0002118">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051705"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0002120 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0002120"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0003008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0003008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0003014 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0003014">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0003008"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0006810 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0006810">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051234"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0006950 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0006950">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050896"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007588 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007588">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0003008"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007589 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007589">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0046903"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050878"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007600 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007600">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050877"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007601 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007601">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0050953"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002104"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050953"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002104"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007605 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007605">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050954"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007606 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007606">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007600"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005726"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007608 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007608">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007606"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005725"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007610 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007610">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050896"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007617 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007617">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044705"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007618 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007618">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044703"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007619 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007619">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007617"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">courtship</oboInOwl:hasExactSynonym>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007620 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007620">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007618"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">copulate</oboInOwl:hasExactSynonym>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007622 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007622">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0048511"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007623 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007623">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0048511"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007626 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007626">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">locomotion</oboInOwl:hasExactSynonym>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007631 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007631">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007610"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007632 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007632">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009416"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044704"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007635 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007635">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0042221"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0007638 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007638">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009612"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0008049 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0008049">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0060179"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0008050 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0008050">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0060180"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0008150 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0008150"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009266 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009266"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009314 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009314">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009628"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009414 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009414">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0006950"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009415"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009415 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009415">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0001101"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009628"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0010035"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_1901700"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009416 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009416">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009314"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009581 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009581"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009582 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009582"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009593 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009593">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0042221"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051606"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009605 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009605">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050896"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009612 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009612"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0009628 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0009628">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050896"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0010035 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0010035">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0042221"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0010996 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0010996"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0016048 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0016048">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009266"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009581"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009582"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0019098 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0019098">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007610"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0022414"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0019230 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0019230">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007600"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0019232 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0019232">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0019230"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0019233 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0019233">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007600"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0022410 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0022410">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0048512"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0022414 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0022414">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0030421 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0030421">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007588"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0030431 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0030431">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0031223 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0031223">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007638"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0010996"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0032501 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0032501">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0032941 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0032941"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0033057 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0033057"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0035176 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0035176">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051703"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051705"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0040011 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0040011">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0042221 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0042221">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050896"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0042747 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0042747">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0022410"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0042748 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0042748">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0022410"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0042755 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0042755">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007631"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0042756 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0042756">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007631"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044699 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044699">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044702 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044702"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044703 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044703"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044704 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044704">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0019098"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044702"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044705 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044705"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044707 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044707">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0032501"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044699"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044708 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044708">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007610"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044699"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0044765 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044765"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0045297 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0045297">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044704"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">post-copulatory behavior</oboInOwl:hasExactSynonym>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0046903 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0046903">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044765"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0048511 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0048511">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044699"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0048512 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0048512">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007623"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0048583 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0048583">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050789"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050789 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050789"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050795 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050795">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0048583"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050802 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050802"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050877 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050877">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0003008"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050878 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050878">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0065008"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050879 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050879">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050881 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050881">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050879"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002204"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050882 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050882">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050881"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050884 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050884">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050905"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050896 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050896">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050905 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050905">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050877"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050906 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050906">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051606"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050907 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050907">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009593"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050906"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050909 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050909">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007606"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001033"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050951 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050951">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007600"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050953 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050953">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007600"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050954 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050954">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007600"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050955 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050955">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050951"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050957 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050957">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007600"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050961 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050961">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0016048"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050906"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050963 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050963">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050906"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050981"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050965 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050965">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050961"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050966 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050966">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050974"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050967 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050967">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050963"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050968 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050968">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050907"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050974 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050974">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050906"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050982"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050975 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050975">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050954"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050981 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050981">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009582"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051602"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0050982 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050982">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009581"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009582"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009612"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0051234 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0051234"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0051602 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0051602"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0051606 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0051606"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0051703 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0051703"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0051704 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0051704">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0051705 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0051705">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007610"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0051704"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0060004 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060004">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009605"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0060073 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060073">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0003014"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007588"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0060179 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060179">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0033057"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0060180 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060180">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0033057"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0060259 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060259">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050795"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0060273 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060273">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0060361 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060361">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0040011"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0065007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0065007"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0065008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0065008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0065007"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0070075 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0070075">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007589"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0032941"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_0071625 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0071625">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044704"/>
+        <oboInOwl:hasExactSynonym xml:lang="en">vocalize</oboInOwl:hasExactSynonym>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/GO_1901700 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_1901700">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0042221"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A change of place or position of part of an organism that does not involve the entire organism [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>stationary movement</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body part movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">whole body movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000003">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the complex psychophysiological experience of an individual&apos;s state of mind as interacting with biochemical (internal) and environmental (external) influences.&quot; [wikipedia:Emotions]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>affective behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mood</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emotional behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000005 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000005">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to involuntary movement in response to a stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:57:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>pathological reflexive behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reflexive behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000006 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000006">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000607"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the acquisition and processing of information and/or the storage and retrieval of this information over time.&quot; [GO:jic]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>learning and/or memory behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007611</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">learning and/or memory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving any of the tissues and hard structures surrounding the mouth other than teeth, jaws or filter structures [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mouth part movement</oboInOwl:hasNarrowSynonym>
+        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">other moved mouth parts</oboInOwl:hasNarrowSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mouth movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:xref>GO:0007622</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhythmic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000009 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000009">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007626"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior associated with the specific movement from place to place of an organism.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T12:58:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>pathological locomotory behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotory behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000010 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000010">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior directly related to the production of offspring [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">reproduction</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>reproductive behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0019098</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reproductive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000011 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000011">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;A behavior that occurs predominantly or only, in individuals that are part of a group.&quot; [Wikipedia:Social_behavior]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>social behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0035176</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000012 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000012">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:xref>HP:0001250</oboInOwl:xref>
+        <oboInOwl:xref>MP:0002064</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">seizures/epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000013 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000013">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0040011"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
+        <nbo:IAO_0000115>Movement from place to place of an organism.&quot; [GO:0007626]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">locomotion</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007626</oboInOwl:xref>
+        <oboInOwl:xref>GO:0008344</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000014 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000014">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the interactions between organisms for the purpose of mating.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>mating behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007617</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000015 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000015">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:IAO_0000115>&quot;A behavioral interaction between organisms in which one organism has the intention of inflicting damage on another individual using physical or verbal means.&quot; [wikipedia:Aggression]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggression</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>aggressive behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>agonism</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0002118</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000016 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000016">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
+        <nbo:IAO_0000115>&quot;Behavior relate to the usually upward movement off the ground or other surface through sudden muscular effort in the legs.&quot; [GO:0007630]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">jump</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007630</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jumping behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000017 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of seizing with teeth or jaws an object or organism so as to grip or break the surface covering [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">bite</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biting</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000018 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000018">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
+        <nbo:IAO_0000115>&quot;Emotional behavior related to fear or anxiety.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>fear/anxiety related behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear/anxiety related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000019 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000019">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000748"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of stroking or touching with the tongue [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">lick</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">licking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000020 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A change in place or position of the portion of the organism containing the brain, mouth and main sense organs [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">move head</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000022 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000022">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000006"/>
+        <nbo:IAO_0000115>&quot;Behavior associated with any process in an organism in which a relatively long-lasting adaptive behavioral change occurs as the result of experience.&quot; [wikipedia:Learning]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>learning behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007612</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000023 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000023">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000068"/>
+        <nbo:IAO_0000115>&quot;Movement of the head in the horizontal plane.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">shake head</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head shaking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000024 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000024">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0030431"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000008"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the readily reversible state of reduced awareness and metabolic activity that occurs periodically in many animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:xref>GO:0030431</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleeping behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000025 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000025">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
+        <nbo:IAO_0000115>&quot;An uncontrolled, paroxysmal neuronal discharge in any part of the brain; it may cause physical or mental symptoms and may be convulsive or nonconvulsive&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>epileptic seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unprovoked seizure</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">seizures</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000026 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000026">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving the head in a plane, circularly, pivoting at the neck [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">rotate head</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head rotation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000027 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000027">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of using body parts to pick at, rub and or remove material from exterior covering, e.g., fur, scales, feathers, skin [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">groom</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>grooming behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hygiene</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:xref>GO:0007625</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grooming behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000028 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000028">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
+        <nbo:IAO_0000115>&quot;Absence of voluntary movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T12:59:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">akinesia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000029 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000029">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
+        <nbo:IAO_0000115>&quot;Reduction of voluntary movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>hypokinesia</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bradykinesia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000030 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000030">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
+        <nbo:IAO_0000115>&quot;A kinesthetic behavior which relatively increased.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:09:28Z</dc:date>
+        <oboInOwl:xref>HP:0000752</oboInOwl:xref>
+        <oboInOwl:xref>MP:0001399</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hyperactivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000031 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000031">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
+        <nbo:IAO_0000115>&quot;A kinesthetic behavior which relatively decreased.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:09:41Z</dc:date>
+        <oboInOwl:xref>MP:0001402</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypoactivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000032 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000032">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
+        <nbo:IAO_0000115>&quot;Loss of power of voluntary movement in a muscle through injury or disease of its nerve supply.&quot; [JAX:&lt;new dbxref&gt;]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:18:37Z</dc:date>
+        <oboInOwl:xref>HP:0003470</oboInOwl:xref>
+        <oboInOwl:xref>MP:0000753</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000033 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000033">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
+        <nbo:IAO_0000115>&quot;Paralysis of the extensors of the wrist and fingers.&quot; [JAX:&lt;new dbxref&gt;]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:19:09Z</dc:date>
+        <oboInOwl:xref>MP:0005162</oboInOwl:xref>
+        <rdfs:comment>Carpoptosis is most often caused by a lesion of the radial nerve.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">carpoptosis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000034 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000034">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
+        <nbo:IAO_0000115>&quot;Behaviour related to the activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual actions</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual activity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000035 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000035">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emission behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000036 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000036">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000035"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">produce sound</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of production of sound</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000037">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000036"/>
+        <nbo:IAO_0000115>&quot;A behavior in which an organism produces sounds by a mechanism involving its respiratory system.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>vocalization behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">vocalize</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vocalization behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000038 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000038">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000035"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007588"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000035"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007588"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;The elimination by an organism of the waste products that arise as a result of metabolic activity. These products include water, carbon dioxide (CO2), and nitrogenous compounds.&quot; [wikipedia:Excretion]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:xref>GO:0007588</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of excretion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000039 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000039">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000038"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0030421"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000038"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0030421"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The behavioral control of defecation. [wikipedia:defecation]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of defecation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000040 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000040">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000038"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001256"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0060073"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000038"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001256"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0060073"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;The regulation of body fluids process by which parasympathetic nerves stimulate the bladder wall muscle to contract and expel urine from the body.&quot; [wikipedia:urination]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>micturition</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">urinate</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0060073</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of urination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000041 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000041">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000035"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007589"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000035"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007589"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior associated with and resulting in the production and subsequent release of any substance or product elaborated, and released by a cell or gland [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">secrete</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of external secretion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000042 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000042">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000041"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001817"/>
+                    </owl:Restriction>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0070075"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000041"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001817"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0070075"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;The regulated release of the aqueous layer of the tear film from the lacrimal glands.&quot; [wikipedia:lacrimation]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">tear release</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>tear secretion</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of lacrimation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000043 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000043">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>forming of peer relationship</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bonding behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000044 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000044">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior associated with protection, or assisting growth and development of young. [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:xref>GO:0060746</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">parental behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000045 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000045">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000048"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior that serves to regulate the temperature around offspring.[NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermoregulation of offspring</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brooding behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000047 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000047">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>weaning behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">weaning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000048 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000048">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115>&quot;Behavior related the protection of offspring.&quot; [NBO:SD]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">protection of offspring</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protection of offspring behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000049 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000049">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
+        <nbo:IAO_0000115>&quot;Play behavior that is associated with the socialization of an individual into the group.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Play%20Fighting.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000625</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>social playing behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social play</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000051 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000051">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the actions by which an organism modulates its internal body temperature.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermoregulation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000052 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000052">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000051"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior associated with two or more individuals&apos; achieving or maintaining close and extensive bodily contact; to nestle closely with another [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">huddle</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">huddling behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000053 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000053">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000051"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exposure of body to sunlight, either by modification of body posture, by movement to specific areas or both [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">basking</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">sunning</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">sunning behavior</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basking behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000054 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000054">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
+        <nbo:IAO_0000115>&quot;Specific actions of a newborn or infant mammal that result in the derivation of nourishment from the breast.&quot; [GOC:dph]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000046</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>nursing behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>suckling behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0001967</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suckling behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000055 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000055">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of locomoting on limbs with body off the ground such that periodically none of the limbs are touching the ground [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">run</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">running behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000056 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000056">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
+        <nbo:IAO_0000115 xml:lang="en">The act of locomoting on limbs with body off the ground such that at least one limb is always touching the ground [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">walking</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007628</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">walking behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000057 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000057">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of dragging claws or nails over a surface [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">scratch</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">scratching behavior</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scratching</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000059 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000059">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nuzzling</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000060 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000060">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Male&apos;s insertion of sperm-transfer organ into the body of the female [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">copulate</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">copulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000061 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000061">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
+        <nbo:IAO_0000115>&quot;Loss of power of voluntary movement in muscles of the forelimb through injury or disease of it or its nerve supply.&quot; [JAX:]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:xref>MP:0000756</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">forelimb paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000062 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the washing or cleansing of the body in a fluid, usually water or an aqueous solution.&quot; [wikipedia:Bathing]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">bathe</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bathing behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bathing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000063 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000063">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000134"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002436"/>
+        <nbo:IAO_0000115>&quot;A feeding behavior associated with the intake or the frequency of intake or preference or manner of intake of food.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>eating behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0042755</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of eating behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000064 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000064">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002436"/>
+        <nbo:IAO_0000115>&quot;A feeding behavior associated with the intake or the frequency of intake or preference or manner of intake of liquids.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>drinking behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0042756</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of drinking behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000065 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000065">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Behavior related to a variety of aspects of the relationship between the mind and the world with which it interacts.&quot; [wikipedia:Consciousness]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">consciousness behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000066 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000066">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000649"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the state of being conscious and engages in a coherent cognitive and behavior responses to the external world.&quot; [NBO:SD, wikipedia:Wakefulness]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wakefulness</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000067 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000067">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
+        <nbo:IAO_0000115>&quot;Behavior related to reduced or absent consciousness, relatively suspended sensory activity, and inactivity of nearly all voluntary muscles.&quot; [wikipedia:Asleep]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">asleep</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000068 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000068">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:IAO_0000115>&quot;Repetitive movement of a body part.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shaking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000069 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000069">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swaying</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000070 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000070">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tilting</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000071 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000071">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the movement facilitated by the generation of hole or tunnel dug into the ground.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">burrowing</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>burrowing behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fossorial locomotion behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000073 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000073">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of repeated grinding, tearing, and or crushing with teeth or jaws [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">chew</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">gnaw</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>mastication</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chewing</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000074 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000074">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yawning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000075 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000075">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A very broad category including the partial or complete performance of adult functional behaviors in non-functional contexts, as well as interactive behaviors peculiar to immature animals [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">play</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">playing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000076 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000076">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Undirected behavior involving exercise and coordination, and often associated with repetition and &apos;practice&apos; of adult behavior patterns in a non-functional context  [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>exercise</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>motor development playing behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">motor play</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Many different actions are included in locomotor play. Some of the actions include a vertical leap, running in circles, chasing an animals own tail, lolloping, bouncing, bucking, rolling, whirling, dangling, spinning, back flips, hand stands, somersaults, and hanging upside down. The vertical leap is seen in mammals like in primates, hares, and mice. Along with running and bouncing, the vertical leap is important for strengthening leg muscles for self defense, escaping, or chasing. Activities like dangling and hanging upside down are important for improving climbing ability. These many different examples of locomotor play are important in strengthening muscles and improving motor skills. By participating in locomotor play, individuals will be able to improve skills like fighting, hunting, fleeing, and climbing.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotor play</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000077 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000077">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000014"/>
+        <nbo:IAO_0000115>&quot;The behavioral interactions between organisms for the purpose of attracting sexual partners.&quot; [GOC:dph]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">courtship</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>courtship behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007619</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">courtship behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000078">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the specific actions or reactions of an organism following mating.&quot; [GOC:bf]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000325</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>post mating behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">post-copulatory behavior</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>post-mating behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0045297</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">post-mating behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000079 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000079">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001845"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33290"/>
+                            </owl:Restriction>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                            </owl:Restriction>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of bringing an object or substance into the body by swallowing, surrounding or absorbing it [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>feeding behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007631</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feeding behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000080 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000080">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving the body core lower, closer to the ground [NOB:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">sit down</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sitting down</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000081 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000081">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving the body core higher, away from the ground [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">stand up</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">standing up</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000082 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000082">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">writhe</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">writhing</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000084 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000084">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007622"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007623"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007622"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000008"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007623"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to any biological process in an organism that recurs with a regularity of approximately 24 hours.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:xref>GO:0048512</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000085 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000085">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:IAO_0000115>&quot;Emotional behavior related to a state of low mood  and aversion to activity.&quot; [wikipedia:Depression]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>depression related behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">depression behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000086 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000086">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel object, situation or environment.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">novelty response behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000087 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000087">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115>&quot;Behavior related to defence against predation or predators.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">antipredator behavior</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">antipredation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000088 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000088">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000087"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000470"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the preparation of the body to \&quot;fight\&quot; or \&quot;flee\&quot; from perceived attack, harm or threat.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>fight-or-flight response</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fight-or-flight-or-freeze response</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acute stress response</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000089 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000089">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000120"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
+        <nbo:IAO_0000115>&quot;A physical aggression behavior involving attack on prey by a predator.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>predatory aggression</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>predatory aggressive behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0002120</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">predator behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000090 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000090">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000087"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior directed at a predator that signifies hostility and predicts an increased probability of attack [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">threaten predator</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">threatening predator behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000091 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000091">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000018"/>
+        <nbo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness triggered by a specified triggering stimulus such as pain or the threat of danger.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:00:42Z</dc:date>
+        <oboInOwl:hasExactSynonym>fear-related behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear-related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000092 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000092">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000018"/>
+        <nbo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness triggered by an identifiable triggering stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:01:25Z</dc:date>
+        <oboInOwl:hasExactSynonym>anxiety-related behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anxiety-related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000093 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000093">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
+        <nbo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness in respect to an object.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:16:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear behavior towards objects</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000094 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000094">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000100"/>
+        <nbo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness in respect to a particular situation or environment.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:18:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear behavior towards situation/environment</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000095 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000095">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
+        <nbo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness in respect to a living thing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:18:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear behavior towards living things</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000096 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000096">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000094"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000246"/>
+        <nbo:IAO_0000115>&quot;A phobia characterised by fear of open spaces.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:18:39Z</dc:date>
+        <oboInOwl:xref>HP:0000756</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">agoraphobia behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000097 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000097">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000086"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel environment.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:22:03Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response to novel environment</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000098 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000098">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000086"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel obhject.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:23:07Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response to novel object</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000099 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000099">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000086"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel odor.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:24:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response to novel odor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000100 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000100">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000097"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:28:39Z</dc:date>
+        <oboInOwl:xref>GO:0035640</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exploration behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000101 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000101">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000056"/>
+        <nbo:IAO_0000115>&quot;Moving backwards.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:32:40Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">retropulsion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000102 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000102">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000100"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000101"/>
+        <nbo:IAO_0000115>&quot;Moving backwards in response to a fear stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:36:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear-related retropulsion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000103 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000103">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
+        <nbo:IAO_0000115>&quot;Behavioral response to the presidency of the stressor where it becomes necessary to attempt some means of coping with the stress.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:49:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coping behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000104 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000104">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards humans.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:50:52Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards humans</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards humans</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000105 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000105">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000740"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:51:12Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards animals</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards animals</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000106 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000106">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000740"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action toward any type of object.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:51:33Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards objects</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards objects</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000107 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000107">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards mice.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:51:50Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards mice</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards mice</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000108 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000108">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000117"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards women.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:52:04Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards women</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards women</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000109 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000109">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000104"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000118"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards men.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:52:26Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards men</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards men</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000110 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000110">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000107"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000118"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards male mice.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:52:56Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards male mice</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards male mice</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000111 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000111">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000107"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000117"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards female mice.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:53:07Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards female mice</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards female mice</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000112 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000112">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000106"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action toward inanimate objects.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:53:44Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards inanimate objects</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards inanimate objects</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000113 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000113">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000106"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action toward inanimate objects.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:53:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards animate objects</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards animate objects</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000114 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000114">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000104"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards children.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:57:11Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards children</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards children</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000115 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000115">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000107"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards pups.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T10:58:09Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards pups</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards pups</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000116 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000116">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
+        <nbo:IAO_0000115>&quot;Gender related exhibition of a domineering, assault posture and/or hostile physical action.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:02:17Z</dc:date>
+        <oboInOwl:hasExactSynonym>gender-related aggressive behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gender-related aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000117 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards female animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:03:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards females</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000118 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000118">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
+        <nbo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards male animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:04:03Z</dc:date>
+        <oboInOwl:hasExactSynonym>aggressive behavior towards males</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards males</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000119 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000119">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;A behavior that occur quickly without control, planning, or consideration of the consequences of that behavior.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:08:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">impulsive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000120 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000120">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000741"/>
+        <nbo:IAO_0000115>&quot;An aggressive behavior that aims to inflicting damage on another entity using physical means.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:14:04Z</dc:date>
+        <oboInOwl:hasExactSynonym>physical aggression behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>violent behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">physical aggression behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000121 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000121">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:42:15Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">agonism</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">agonistic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000122 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000122">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any behavior that tends to prevent further or future attack, often by signalling a willingness to yield or surrender [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:43:11Z</dc:date>
+        <oboInOwl:hasExactSynonym>submissive behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">submissive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000123 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000123">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000122"/>
+        <nbo:IAO_0000115>&quot;A behavior associated with the tendency of an organism towards being passive and willing to yield to male animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:43:37Z</dc:date>
+        <oboInOwl:hasExactSynonym>submissive behavior towards males</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">submissive behavior towards males</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000124 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000124">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000122"/>
+        <nbo:IAO_0000115>&quot;A behavior associated with the tendency of an organism towards being passive and willing to yield to female animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:44:14Z</dc:date>
+        <oboInOwl:hasExactSynonym>submissive behavior towards females</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">submissive behavior towards females</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000125 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000125">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000123"/>
+        <nbo:IAO_0000115>&quot;A behavior associated with the tendency of an organism towards being passive and willing to yield towards male mice.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:44:25Z</dc:date>
+        <oboInOwl:hasExactSynonym>submissive behavior towards male mice</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">submissive behavior towards male mice</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000126 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000126">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000122"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:47:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">subordination behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000127 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000127">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior by which an animal removes itself spatially from an agonistic encounter in which it is not the winner [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T11:49:03Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">retreat</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>retreat behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">retreat behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000128 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000128">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115>&quot;Behavior characterized by a quick excitability to annoyance, impatience, or anger.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:16:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">irritability behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000129 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000129">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:IAO_0000115>&quot;Emotional behavior related to excitement or restlessness.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:22:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">agitation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000130 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000130">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000145"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A behavior associated with the intake of liquid.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:40:37Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000131 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000131">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16236"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16236"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A drinking behavior associated with the intake of alcohol.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:40:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000132 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000132">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_15377"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_15377"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A drinking behavior associated with the intake of water.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:41:14Z</dc:date>
+        <oboInOwl:xref>GO:0045187</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">water consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000133 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000133">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000161"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000540"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:41:50Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid preference/aversion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000134 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000134">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000079"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33290"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33290"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A feeding behavior associated with the intake of food.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:42:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000135 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000135">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0060259"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000161"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:43:07Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food preference/aversion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000136 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000136">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000134"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32111"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000134"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32111"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A feeding behavior associated with the intake of saccharin.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:50:41Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saccharin consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000137 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000137">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002660"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000912"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000133"/>
+        <nbo:IAO_0000115>&quot;Predilection to ingest a liquid over other substances.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:55:09Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000138 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000138">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002660"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000911"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000133"/>
+        <nbo:IAO_0000115>&quot;Purposeful avoidance of a liquid due to dislike.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:55:32Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid aversion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000139 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000139">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002702"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000911"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000138"/>
+        <nbo:IAO_0000115>&quot;Purposeful avoidance of liquid alcohol due to dislike.&quot; [NBO:GVG] [NBO:LKSR]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:55:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol aversion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000140 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000140">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002702"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000912"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000137"/>
+        <nbo:IAO_0000115>&quot;Predilection to ingest alcohol over other substances.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:56:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000141 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000141">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0060259"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000912"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000135"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:58:43Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000142 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000142">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0060259"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000911"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000135"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:59:08Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food aversion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000143 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000143">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002794"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000912"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000141"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T12:59:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saccharin preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000144 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000144">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007617"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000044"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000756"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:16:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating frequency</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000145 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000145">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002948"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000161"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000756"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:17:22Z</dc:date>
+        <oboInOwl:hasExactSynonym>mate choice</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000146 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000146">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000014"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:17:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating receptivity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000147 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000147">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000014"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:21:53Z</dc:date>
+        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mate attraction behavior</oboInOwl:hasNarrowSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual display behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000148 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000148">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:24:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social investigation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000149 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000149">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:25:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reclusive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000150 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000150">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
+        <nbo:IAO_0000115>&quot;Behavior of a mother towards her offspring.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:32:21Z</dc:date>
+        <oboInOwl:xref>GO:0042711</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000151 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000151">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
+        <nbo:IAO_0000115>&quot;Behavior of a father towards his offspring.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:32:53Z</dc:date>
+        <oboInOwl:xref>GO:0042712</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paternal behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000152 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000152">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000150"/>
+        <nbo:IAO_0000115>&quot;Maternal behavior related to the brining up her offspring.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:33:34Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal nurturing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000153 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000153">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000151"/>
+        <nbo:IAO_0000115>&quot;Paternal behavior related to the brining up his offspring.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:33:49Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paternal nurturing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000154 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000154">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000152"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:35:33Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal crouching</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000155 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000155">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000048"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the parent&apos;s tendency to collect stray offspring and return them to a defined location.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:42:29Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">retrieval</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">offspring retrieval</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000156 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000156">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:53:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nesting behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000157 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000157">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000156"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:54:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nest building behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000158 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000158">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T02:59:33Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep pattern</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000159 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000159">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000024"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0042747"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0042747"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050802"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000024"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0042747"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:00:57Z</dc:date>
+        <oboInOwl:hasExactSynonym>REM sleep</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>paradoxical sleep</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rapid eye movement sleep</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000160 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000160">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0030431"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001309"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:09:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep duration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000161 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000161">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0042748"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050802"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000024"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0042748"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to all sleep stages in the circadian sleep/wake cycle other than REM sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:12:44Z</dc:date>
+        <oboInOwl:hasExactSynonym>NREM sleep behavior</oboInOwl:hasExactSynonym>
+        <rdfs:comment>These stages are characterized by a slowing of brain waves and other physiological functions.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-rapid eye movement sleep behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000162 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000162">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042747"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001309"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000754"/>
+        <nbo:IAO_0000115>&quot;Duration of REM sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:15:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM duration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000163 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000163">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042747"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000044"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000754"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:15:49Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM frequency</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000164 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000164">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000161"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001309"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000160"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000753"/>
+        <nbo:IAO_0000115>&quot;Duration of REM sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:16:07Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NREM duration</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000165 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000165">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000161"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000044"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000753"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:16:10Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NREM frequency</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000166 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000166">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
+        <nbo:IAO_0000115>&quot;Endogenously driven roughly 24-hour cycle in biochemical, physiological, or behavioral processes.&quot; [GOC:bf]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:22:26Z</dc:date>
+        <oboInOwl:xref>GO:0007623</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian rhythm</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000167 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000167">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000166"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:23:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian period</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000168 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000168">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000166"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:23:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian persistence</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000169 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000169">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000166"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-03-31T03:24:52Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian phase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000170 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000170">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000006"/>
+        <nbo:IAO_0000115>&quot;Behavior related with the ability of an organism&apos;s ability to store, retain, and recall information and experiences.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T01:49:03Z</dc:date>
+        <oboInOwl:hasExactSynonym>memory behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007613</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000171 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000171">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000022"/>
+        <nbo:IAO_0000115>&quot;Learning by associating a stimulus (the cause) with a particular outcome (the effect).&quot; [Wikipedia:Learning#Associative_learning]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T01:49:32Z</dc:date>
+        <oboInOwl:hasExactSynonym>conditional learning</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0008306</oboInOwl:xref>
+        <rdfs:comment>The formation of associations among stimuli and responses.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">associative learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000172 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000172">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000323"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000641"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T01:54:09Z</dc:date>
+        <oboInOwl:xref>GO:0008355</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000173 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000173">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000314"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000641"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T01:54:15Z</dc:date>
+        <oboInOwl:xref>GO:0008542</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000174 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000174">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000171"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T01:56:08Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motor learning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000175 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000175">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T01:57:20Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial learning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000176 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000176">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000171"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000037"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000037"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A behavioral process whose outcome is a relatively long-lasting adaptive behavioral change whereby an organism modifies innate vocalizations to imitate or create new sounds.&quot; [GO:0042297]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T01:58:41Z</dc:date>
+        <oboInOwl:xref>GO:0042297</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vocal learning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000177 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000177">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000022"/>
+        <nbo:IAO_0000115>&quot;A decrease in a behavioral response to a repeated stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T03:18:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>nonassociative learning</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unconditional response</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0046958</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-associative learning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000178 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000178">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000177"/>
+        <nbo:IAO_0000115>&quot;Gradual decrease in behavioral responses with repeated encounters of a particular stimulus, which proves of no consequence.&quot; [wikipedia:Habituation]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T03:19:06Z</dc:date>
+        <oboInOwl:xref>GO:0046959</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">habituation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000179 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000179">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000177"/>
+        <nbo:IAO_0000115>&quot;An increase in behavioral responses following repeated applications of a particular stimulus.&quot; [wikipedia:Sensitization]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T03:54:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensitization</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000180 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000180">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
+        <nbo:IAO_0000115>&quot;A type of memory that allows the recall of something from several seconds to as long as a minute.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T03:59:07Z</dc:date>
+        <oboInOwl:xref>GO:0007614</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short-term memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000181 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000181">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
+        <nbo:IAO_0000115>&quot;This type of memory, lasting hours to months, critically depends on a transfer of the information from short term memory using repeated rehearsal.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T03:59:10Z</dc:date>
+        <oboInOwl:xref>GO:0007616</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long-term memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000182 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000182">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
+        <nbo:IAO_0000115>&quot;Report great detail about a complex stimulus immediately following its presentation. This ability forms within a few tens of milliseconds and decays again rapidly within a few hundred milliseconds.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T03:59:19Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensory memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000183 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000183">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
+        <nbo:IAO_0000115>&quot;A memory that last for months to lifetime.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T04:00:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long-lasting memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000184 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000184">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
+        <nbo:IAO_0000115>&quot;A type of memory that allows the recall of something from minutes to several hours.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-01T04:01:02Z</dc:date>
+        <oboInOwl:xref>GO:0072375</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medium term memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000185 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000185">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000181"/>
+        <nbo:IAO_0000115>&quot;Ability to become conscious of, or declare, facts and experiences.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T07:38:45Z</dc:date>
+        <oboInOwl:hasExactSynonym>explicit memory</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Encoded by the hippocampus, entorhinal cortex, and perirhinal cortex but store possibly in the medial temporal lobe.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">declarative memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000186 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000186">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
+        <nbo:IAO_0000115>&quot;Ability to consciously recall knowledge of facts that are independent of a specific time and place.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T07:40:26Z</dc:date>
+        <rdfs:comment>Medial temporal lobe, diencephalon.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">semantic memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000187 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000187">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
+        <nbo:IAO_0000115>&quot;Ability to explicitly recall information about a specific event that has occurred at a specific time and place.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T07:41:30Z</dc:date>
+        <rdfs:comment>Medial temporal lobe, diencephalon.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">episodic memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000188 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000188">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000181"/>
+        <nbo:IAO_0000115>&quot;Non-declarative memory type of memory, which does not need to involve conscious awareness in the act of recollection.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T07:42:37Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000189</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>implicit memory</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>procedural memory</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Encoded and probably stored by the cerebellum and the striatum but store in the amygdala.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-declarative memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000190 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000190">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000188"/>
+        <nbo:IAO_0000115>&quot;Consolidating a specific motor task into memory through repetition.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T07:54:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>muscle memory</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Depends on the cerebellum and basal ganglia.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motor memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000191 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000191">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000181"/>
+        <nbo:IAO_0000115>&quot;A type of memory associated with emotional experiences.&quot; [wikipedia:http\://www.scholarpedia.org/article/Emotional_memory]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T07:59:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emotional memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000192 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000192">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
+        <nbo:IAO_0000115>&quot;Remembering to perform an intended action.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:16:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prospective memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000193 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000193">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000192"/>
+        <nbo:IAO_0000115>&quot;Remembering to perform an intended action in respect to a particular event.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:19:20Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">event-based prospective memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000194 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000194">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000192"/>
+        <nbo:IAO_0000115>&quot;Remembering to perform an intended action in respect to a particular time reference.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:19:37Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">time-based prospective memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000195 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000195">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000187"/>
+        <nbo:IAO_0000115>&quot;A type of memory for particular events within one&apos;s own life.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:27:14Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">autobiographical memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000196 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000196">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
+        <nbo:IAO_0000115>&quot;Ability to store and retrieve previously experienced visual sensations and perceptions when the stimuli that originally evoked them are no longer present.&quot; [wikipedia:Visual_memory]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:33:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000197 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000197">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000182"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:37:43Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iconic memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000198 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000198">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000182"/>
+        <nbo:IAO_0000115>&quot;The ability to recall images, sounds, or objects in memory with extreme precision and in abundant volume.&quot; [wikipedia:Eidetic_memory]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:39:24Z</dc:date>
+        <oboInOwl:hasExactSynonym>photographic memory</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eidetic memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000199 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000199">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
+        <nbo:IAO_0000115>&quot;Ability to orient oneself in space, to recognize and follow an itinerary, or to recognize familiar places.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:42:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">topographic memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000200 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000200">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000307"/>
+        <nbo:IAO_0000115>&quot;An implicit memory effect in which exposure to a stimulus influences response to a later stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:50:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">priming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000201 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000201">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:55:04Z</dc:date>
+        <oboInOwl:hasExactSynonym>repetition</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">direct priming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000202 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000202">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
+        <nbo:IAO_0000115>&quot;A type of priming where the prime and the target are from the same semantic category and share features.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:56:35Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">semantic priming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000203 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000203">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
+        <nbo:IAO_0000115>&quot;A type of priming where the target is a word that has a high probability of appearing with the prime, and is \&quot;associated\&quot; with it but not necessarily related in semantic features.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:57:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">associative priming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000204 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000204">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:58:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response priming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000205 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000205">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
+        <nbo:IAO_0000115>&quot;A type of priming based on the meaning of a stimulus and is enhanced by semantic task.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T08:59:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conceptual priming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000206 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000206">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
+        <nbo:IAO_0000115>&quot;A type priming based on the form of the stimulus and is enhanced by the match between the early and later stimuli.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T09:00:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perceptual priming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000207 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000207">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000178"/>
+        <nbo:IAO_0000115>&quot;Change in the responsiveness of a sensory system when confronted with a constant stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-02T09:07:54Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensory adaptation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000208 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000208">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:IAO_0000115>&quot;A form of associative learning that requires an unconditional reflex, where an unconditional stimulus (US)brings about an automatic, unlearned (unconditional) response (UR). If a neutral stimulus (NS) tends to precede it, an association is made and the conditional response (CR) becomes transferred onto the (previously neutral) conditional strimulus (CS); a conditional reflex has been learned.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T08:57:28Z</dc:date>
+        <oboInOwl:hasExactSynonym>Pavlovian conditioning</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>respondent conditioning</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">classical conditioning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000209 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000209">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000208"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000778"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A type of associative learning that allows organisms to acquire affective responses, such as fear, in situations where a particular context or stimulus is predictably elicits fear via an aversive context.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T08:58:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear conditioning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000210 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000210">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T09:01:08Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">avoidance learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000211 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000211">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000208"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T09:04:57Z</dc:date>
+        <oboInOwl:hasExactSynonym>Garcia conditioning</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0001661</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conditioned taste aversion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000212 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000212">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:IAO_0000115>&quot;Operant conditioning is the use of a behavior&apos;s antecedent and/or its consequence to influence the occurrence and form of behavior.&quot; [wikipedia:Operant_conditioning]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T09:05:54Z</dc:date>
+        <oboInOwl:hasExactSynonym>instrumental conditioning</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>instrumental learning</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0035106</oboInOwl:xref>
+        <rdfs:comment>Operant conditioning is distinguished from classical conditioning in that operant conditioning deals with the modification of &quot;voluntary behavior&quot; or operant behavior.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">operant conditioning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000213 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000213">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T09:08:06Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">imprinting behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000214 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000214">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T09:11:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">latent learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000215 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000215">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000220"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T09:11:31Z</dc:date>
+        <oboInOwl:hasExactSynonym>modeling</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>vicarious learning</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">observational learning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000216 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000216">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000022"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000745"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000022"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000745"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-03T09:11:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">language learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000217 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000217">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000210"/>
+        <nbo:IAO_0000115>&quot;Avoidance learning when the action occurs.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:22:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">active avoidance learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000218 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000218">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000210"/>
+        <nbo:IAO_0000115>&quot;Avoidance learning when no action occurs.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:22:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">passive avoidance learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000219 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000219">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000210"/>
+        <nbo:IAO_0000115>&quot;Avoid a situation completely.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:25:10Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">escape learning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000220 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000220">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:IAO_0000115>&quot;The sociological process of training individuals in a society to act or respond in a manner generally approved by the society in general and peer groups within society.&quot; [wikipedia:Social_conditioning]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:34:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social learning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000221 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000221">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000171"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000778"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000778"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:36:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conditioned emotional response</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000222 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000222">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:40:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conditioned place preference behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000223 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000223">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:42:37Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">contextual conditioning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000224 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000224">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:43:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cued conditioning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000225 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000225">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:IAO_0000115>&quot;Perception of objects remains the same despite changes in their image on the retina.&quot; [:http\://science.jrank.org/pages/5094/Perception.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:47:32Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perceptual constancy behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000226 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000226">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:48:50Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spinal conditioning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000227 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000227">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000208"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000749"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000208"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000749"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:55:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye blink conditioning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000228 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000228">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000208"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000208"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T03:57:01Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jaw movement conditioning behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000229 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000229">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000317"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000656"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the awareness of body balance and movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T06:34:21Z</dc:date>
+        <oboInOwl:hasExactSynonym>pathological vestibular behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibular behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000230 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000230">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T07:49:51Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleasure behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000231 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000231">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T07:50:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">excitement behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000232 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000232">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T07:50:20Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">distress behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000233 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000233">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the tendency of an organism to maintain internal equilibrium.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:29:40Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000050</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>behavioral homeostasis</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>maintenance behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>perception of need</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motivation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000234 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000234">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009414"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the deprivation of water.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:29:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thirst motivation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000235 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000235">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the deprivation of food.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:30:11Z</dc:date>
+        <oboInOwl:hasExactSynonym>appetite related behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hunger motivation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000236 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000236">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the drive of an organism to engage in sexual activity.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:30:39Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual motivation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000237 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000237">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
+        <nbo:IAO_0000115>&quot;Any process which modulates the physical craving for food.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:33:16Z</dc:date>
+        <oboInOwl:xref>GO:0032098</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hunger regulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000238 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000238">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000237"/>
+        <nbo:IAO_0000115>&quot;Any process which modulates the physical craving for food over short term food deprivation.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:33:34Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term hunger regulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000239 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000239">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000237"/>
+        <nbo:IAO_0000115>&quot;Any process which modulates the physical craving for food over long term food deprivation.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:33:49Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term hunger regulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000240 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000240">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:35:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anorexia nervosa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000241 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:36:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bulimia nervosa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000242 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000242">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:36:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obesity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000243 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000243">
+        <nbo:IAO_0000115>&quot;An observable characteristic of the behavior of an organism.&quot; [NBO:RH]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:51:24Z</dc:date>
+        <oboInOwl:xref>HP:0000708</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000244 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000244">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:51:52Z</dc:date>
+        <oboInOwl:hasExactSynonym>hysteria</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pathological anxiety disorder</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pathological anxiety</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000245 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000245">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
+        <nbo:IAO_0000115>&quot;A pathological anxiety characterized by long-lasting anxiety that is not focused on any one object or situation.&quot; [wikipedia:Generalized_anxiety_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:52:08Z</dc:date>
+        <oboInOwl:hasExactSynonym>GAD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">generalized anxiety</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000246 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000246">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
+        <nbo:IAO_0000115>&quot;A pathological anxiety characterized by fear or anxiety triggered by a specific stimulus or situation.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:52:18Z</dc:date>
+        <oboInOwl:hasExactSynonym>phobic disorder</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phobia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000247 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000247">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
+        <nbo:IAO_0000115>&quot;A pathological anxiety characterized by brief attacks of intense terror and apprehension, often marked by trembling, shaking, confusion, dizziness, nausea, difficulty breathing.&quot; [wikipedia:Panic_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:52:30Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">panic</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000248 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000248">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
+        <nbo:IAO_0000115>&quot;A pathological anxiety primarily characterized by repetitive obsessions (distressing, persistent, and intrusive thoughts or images) and compulsions (urges to perform specific acts or rituals).&quot; [wikipedia:Obsessive%E2%80%93compulsive_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:52:42Z</dc:date>
+        <oboInOwl:hasExactSynonym>OCD</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0000722</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obsessive-compulsive disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000249 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000249">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:IAO_0000115>&quot;A pathological behavior characterized by one or more symptoms of a physical dysfunction but for which there is no identifiable organic cause.&quot; [wikipedia:Somatoform_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:53:04Z</dc:date>
+        <oboInOwl:hasExactSynonym>pathological somatoform behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somatoform behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000250 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000250">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000249"/>
+        <nbo:IAO_0000115>&quot;A somatoform disorder characterised by a physical dysfunction (blindness, deafness, paralysis, numbness, etc. ) that has no underlying organic basis.&quot; [wikipedia:Conversion_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:53:18Z</dc:date>
+        <oboInOwl:hasExactSynonym>hysteria</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conversion disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000251 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000251">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000249"/>
+        <nbo:IAO_0000115>&quot;A somatoform disorder characterised by a continuing belief that one has one or more serious illnesses although no medical evidence supports the belief.&quot; [wikipedia:Hypochondriasis]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:53:49Z</dc:date>
+        <oboInOwl:hasExactSynonym>health anxiety</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>health phobia</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hypochondria</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypochondriasis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000252 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000252">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:54:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative disorders</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000253 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000253">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000252"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:54:26Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative amnesia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000254 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000254">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000252"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:54:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative fugue</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000255 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000255">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000252"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:54:45Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative identity disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000256 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000256">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:55:19Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mood disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000257 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000257">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:55:36Z</dc:date>
+        <oboInOwl:hasExactSynonym>MDD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>clinical depression</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>major depression</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>unipolar depression</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">major depressive disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000258 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000258">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000256"/>
+        <nbo:IAO_0000115>&quot;A mood disorder formerly characterised by alternating periods of mania and depression (and in some cases rapid cycling, mixed states, and psychotic symptoms).&quot; [wikipedia:Bipolar_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:55:45Z</dc:date>
+        <oboInOwl:hasExactSynonym>BD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>bipolar affective disorder</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>manic depression</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>NBO:0000258</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bipolar disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000259 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000259">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:56:39Z</dc:date>
+        <oboInOwl:xref>HP:0000709</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">psychotic disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000260 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000260">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:56:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paranoid schizophrenia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000261 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000261">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:57:08Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catatonic schizophrenia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000262 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000262">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:57:19Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disorganized (hebephrenic) schizophrenia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000263 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000263">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:57:32Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">undifferentiated schizophrenia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000264 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000264">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:57:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">residual schizophrenia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000265 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000265">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T08:59:01Z</dc:date>
+        <oboInOwl:xref>HP:0000751</oboInOwl:xref>
+        <rdfs:comment>(http://www.cliffsnotes.com/study_guide/Classifying-Psychological-Disorders.topicArticleId-25438,articleId-25396.html).</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">personality disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000266 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000266">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000607"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to cognitive processes.&quot; [NBO:RH]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:01:18Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cognitive behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000267 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000267">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:01:41Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delirium</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000268 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000268">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:01:50Z</dc:date>
+        <oboInOwl:xref>HP:0000726</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dementia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000269 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000269">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:02:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amnestic disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000270 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000270">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000079"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior associated with the intake of food or liquids.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:02:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feeding behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000271 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000271">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behaviors that are described for or done by groups of animals, not individual animals [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:05:23Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">group actions</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">group behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000272 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000272">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:05:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social facilitation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000273 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000273">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:05:52Z</dc:date>
+        <oboInOwl:hasExactSynonym>social loafing</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social interference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000274 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000274">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:06:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">group polarization</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000275 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000275">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:06:30Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">groupthink</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000276 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000276">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000015"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000037"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000741"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000037"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A behavioral interaction between organisms in which one organism exhibits aggression using vocal or verbal means.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:07:58Z</dc:date>
+        <oboInOwl:hasExactSynonym>verbal aggression behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vocal aggression behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000277 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000277">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:11:04Z</dc:date>
+        <oboInOwl:hasExactSynonym>&lt;new synonym&gt;</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>discrimination</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>prejudice</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">discriminatory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000278 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000278">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000277"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:12:21Z</dc:date>
+        <oboInOwl:hasExactSynonym>sexism</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gender specific discriminatory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000279 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000279">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000277"/>
+        <nbo:IAO_0000115>&quot;A discriminatory behavior that is related to age.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:12:49Z</dc:date>
+        <oboInOwl:hasExactSynonym>ageism</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">age specific discriminatory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000280 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000280">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:16:35Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">attraction-related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000281 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000281">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
+        <nbo:IAO_0000115>&quot;Behavior related to having a generally positive attitude toward another person.&quot; [MBP:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:16:54Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">affiliation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000282 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000282">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
+        <nbo:IAO_0000115>&quot;Wanting to be with another person.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:17:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000283 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000283">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000282"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:17:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">friendship</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000284 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000284">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000282"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:18:24Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">love</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000285 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000285">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000286"/>
+        <nbo:IAO_0000115>&quot;A helping behavior (without expectation of extrinsic rewards and sometimes involving personal risk or sacrifice) that benefits individuals or society.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:19:33Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">altruism behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000286 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000286">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:IAO_0000115>&quot;Prosocial behavior is caring about the welfare and rights of others, feeling concern and empathy for them, and acting in ways that benefit others.&quot; [wikipedia:Prosocial_behavior]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:22:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prosocial behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000287 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000287">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000286"/>
+        <nbo:IAO_0000115>&quot;Helping behavior refers to voluntary actions intended to help the others, with reward regarded or disregarded.&quot; [wikipedia:Helping_behavior]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:23:26Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helping behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000288 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000288">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000286"/>
+        <nbo:IAO_0000115>&quot;Reciprocal altruism is the idea that the incentive for an individual to help in the present is based on the expectation of the potential receipt in the future.&quot; [wikipedia:Helping_behavior]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:25:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reciprocal altruism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000289 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000289">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:26:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social influence related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000290 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000290">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000289"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:27:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conformity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000291 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000291">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000289"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:27:43Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obedience to authority</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000292 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000292">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000289"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:27:57Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bystander intervention</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000293 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000293">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000607"/>
+        <nbo:IAO_0000115>&quot;Behavior related to one or more capacities of the mind.&quot; [wikipedia:Intelligence]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:30:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from intelligence</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000294 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000294">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
+        <nbo:IAO_0000115>&quot;Behavior stemming from the ability to identify, assess, and control the emotions of oneself, of others, and of groups.&quot; [wikipedia:Emotional_intelligence]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:30:47Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from emotional intelligence</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000295 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000295">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000238"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-18T10:37:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">satiation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000296 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000296">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior that facilitates the restoration of normal interactions between parties that recently engaged in a conflict.[NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T09:50:09Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">reconciliation</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">reconciliation behavior</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conciliation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000297 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000297">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
+        <nbo:IAO_0000115>&quot;Behavior associated with problem finding and problem shaping.&quot; [wikipedia:Problem_solving]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:31:35Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from problem solving</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000298 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000298">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
+        <nbo:IAO_0000115>&quot;Behavior stemming from intelligence associated with the capacity of conveying information. (Example: behavior adaptation in chimpanzees in order to communicate with humans.)&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:31:52Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from communication intelligence</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000299 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000299">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:36:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alloparental behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000300 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000300">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
+        <nbo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by male animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:39:19Z</dc:date>
+        <oboInOwl:hasExactSynonym>male aggressive behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0001966</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000301 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000301">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
+        <nbo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by female animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:39:49Z</dc:date>
+        <oboInOwl:hasExactSynonym>female aggressive behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000302 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000302">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000048"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000150"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000301"/>
+        <nbo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by a mother or attending female.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:39:58Z</dc:date>
+        <oboInOwl:hasExactSynonym>maternal aggression</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0002125</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000303 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000303">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000048"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000151"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000300"/>
+        <nbo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by a father or attending male.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:40:11Z</dc:date>
+        <oboInOwl:hasExactSynonym>paternal aggression</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paternal aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000304 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000304">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
+        <nbo:IAO_0000115>&quot;Behavior related with the gradual loss of information and experiences stored in the memory of an organism.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:49:14Z</dc:date>
+        <oboInOwl:hasExactSynonym>forgetting</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory loss behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:49:41Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory encoding behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000306 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000306">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
+        <nbo:IAO_0000115>&quot;Behavior related with the ability of an organism&apos;s ability to store information and experiences.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:53:48Z</dc:date>
+        <oboInOwl:hasExactSynonym>memory storage behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory storage behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000307 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000307">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
+        <nbo:IAO_0000115>&quot;Behavior related with the ability of an organism&apos;s ability to recall information and experiences.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T09:55:36Z</dc:date>
+        <oboInOwl:hasExactSynonym>memory retrieval behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory retrieval behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000308 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000308">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000607"/>
+        <nbo:IAO_0000115>&quot;Cognitive perception of a sensation by any of the five senses -- vision, touch, smell, taste, and hearing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-04T10:00:45Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000454</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>behavior involving perception</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>perception behavior</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Example: moving head to watch passing object.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000309 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000309">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000246"/>
+        <nbo:IAO_0000115>&quot;A phobia characterised by fear of social or performance situations in which embarrassment may occur.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T09:35:47Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social phobia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000310 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000310">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000246"/>
+        <nbo:IAO_0000115>&quot;A phobia characterised by fear of high places.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T09:36:09Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acrophobia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000311 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000311">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the actions of an organism in relation to sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T09:46:01Z</dc:date>
+        <oboInOwl:hasExactSynonym>sleep motivation behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep motivation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000312 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000312">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000311"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of sleep.&quot; [GOC:jl]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T09:46:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of sleep</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000313 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000313">
+        <nbo:IAO_0000115>&quot;The action, reaction, or performance of an organism in response to external or internal stimuli.&quot; [GO:GO\:0007610]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T09:53:10Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000000</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>behavior</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007610</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior process</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000314 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000314">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000308"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007601"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007601"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the actions or reactions of an organism in response to a visual stimulus.&quot; [GO:0007632]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:36:24Z</dc:date>
+        <oboInOwl:hasExactSynonym>behavioral response to visual stimulus</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>behavioural response to visual stimulus</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>visual behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000315 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000315">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000314"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the actions or reactions of an organism pertaining to movement of the eyes and of objects in the visual field, as in nystagmus.&quot; [GO:0007634]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:37:02Z</dc:date>
+        <oboInOwl:xref>GO:0007634</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optokinetic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000316 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000316">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000308"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007605"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002105"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007605"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the actions or reactions of an organism in response to a sound.&quot; [GO:0031223]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:38:17Z</dc:date>
+        <oboInOwl:hasExactSynonym>hearing behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0031223</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">auditory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000317 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000317">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000327"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the awareness of body balance and movement.&quot; [MBP:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:40:36Z</dc:date>
+        <oboInOwl:hasExactSynonym>proprioception</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibular behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000318 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000318">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:44:05Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">balance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000319 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000319">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:44:19Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body rotation sensation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000320 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000320">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_00000050"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050957"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:44:34Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gravitation sensation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000321 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000321">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:44:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">movement sensation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000322 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000322">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001632"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007606"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001632"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007606"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior as a result of the sensation of chemicals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:48:17Z</dc:date>
+        <oboInOwl:xref>GO:0007635</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemosensory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000323 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000323">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000322"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007608"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000322"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007608"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the sensation of odors.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:48:52Z</dc:date>
+        <oboInOwl:xref>GO:0042048</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000324 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000324">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000322"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050909"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000322"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050909"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T10:50:50Z</dc:date>
+        <oboInOwl:hasExactSynonym>gustatory behavior</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Taste can be described as five basic sensations, sweet, sour, salty, bitter and umamy which can be combined in various ways to make all other taste sensations.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">taste behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000326 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000326">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000330"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050955"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000330"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050955"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to environmental temperature.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T11:00:51Z</dc:date>
+        <oboInOwl:hasExactSynonym>thermosensation behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0040040</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermosensory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000327 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000327">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000751"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the sensations arising from the skin and from the muscles, tendons, and joints.&quot; [OBP:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T11:01:08Z</dc:date>
+        <rdfs:comment>Sensations arising from the internal organs (the viscera), such as pain or the sense of fullness of the stomach or bladder, may therefore be included, although they are usually considered separately as visceral sensations. Pain arising from the viscera is often felt as though it comes from some part of the body surface or underlying tissue.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somatic sensation related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000328 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000328">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000326"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001305"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000326"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001305"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the detection of high environmental temperature.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T11:09:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hot sensation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000329 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000329">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000326"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001306"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000326"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001306"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the detection of low environmental temperature.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T11:09:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cold sensation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000330 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000330">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000327"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T11:11:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cutaneous sensation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000331 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000331">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000330"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0019233"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000330"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0019233"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T11:13:27Z</dc:date>
+        <oboInOwl:hasExactSynonym>nociception</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pain</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nociceptive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000332 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000332">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000330"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050975"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000330"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050975"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T11:36:23Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">touch related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000333 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000333">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000331"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050968"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000331"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050968"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T12:38:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>chemical nociception behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical nociceptive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000334 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000334">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000331"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050966"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000331"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050966"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T12:39:46Z</dc:date>
+        <oboInOwl:hasExactSynonym>mechanical nociception behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mechanical nociceptive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000335 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000335">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000331"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050965"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000331"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050965"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T12:41:15Z</dc:date>
+        <oboInOwl:hasExactSynonym>thermal nociception behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermal nociceptive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000336 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000336">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000331"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T12:45:31Z</dc:date>
+        <oboInOwl:hasExactSynonym>chemically-elicited antinociception behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemically-elicited antinociceptive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000337 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000337">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000330"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T02:06:22Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pressure related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000338 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000338">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Movement behavior of the body or its parts.&quot;</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T02:08:47Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinesthetic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000339 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000339">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
+        <nbo:IAO_0000115>&quot;The coordination of combinations of body movements created with the kinematic (such as spatial direction) and kinetic (force) parameters that result in intended actions.&quot; [wikipedia:Motor_coordination]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T03:32:44Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000340</oboInOwl:hasAlternativeId>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motor coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000341 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000341">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000348"/>
+        <nbo:IAO_0000115>&quot;The coordinated control of eye movement with hand movement, and the processing of visual input to guide reaching and grasping along with the use of proprioception of the hands to guide the eyes.&quot; [wikipedia:Eye%E2%80%93hand_coordination]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T03:43:28Z</dc:date>
+        <oboInOwl:hasExactSynonym>hand eye coordination</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Optic apraxia - total inability of a person to coordinate eye and hand movements.\nOptic ataxia - inability of a person to coordinate eye and hand movements.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye-hand coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000342 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000342">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000347"/>
+        <nbo:IAO_0000115>&quot;The coordination of limb movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T03:49:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">limb coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000343 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000343">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000346"/>
+        <nbo:IAO_0000115>&quot;Coordination that results in spatial and temporal planning of reaching and grasping.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T03:57:56Z</dc:date>
+        <oboInOwl:hasExactSynonym>intra-limb coordination</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intralimb coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000344 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000344">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000346"/>
+        <nbo:IAO_0000115>&quot;Coordination that results in bimanual synchronization and temporal association of the hands.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T03:58:29Z</dc:date>
+        <oboInOwl:hasExactSynonym>inter-limb coordination</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interlimb coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000345 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000345">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000342"/>
+        <nbo:IAO_0000115>&quot;The coordination of lower limb movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T04:05:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lower limb coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000346 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000346">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000342"/>
+        <nbo:IAO_0000115>&quot;The coordination of upper limb movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T04:05:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper limb coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000347 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000347">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
+        <nbo:IAO_0000115>&quot;The coordination of large muscle groups and whole body movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T04:10:52Z</dc:date>
+        <oboInOwl:hasExactSynonym>large muscle coordination</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>whole body coordination</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gross motor coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000348 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000348">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
+        <nbo:IAO_0000115>&quot;Coordination of small muscle movements which occur usually in coordination with the eye.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T04:14:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fine motor coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000349 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000349">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000348"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T04:17:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">manual dexterity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000350 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000350">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
+        <nbo:IAO_0000115>&quot;Coordination involved in writing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T04:19:34Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">graphomotor coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000351 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000351">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000347"/>
+        <nbo:IAO_0000115>&quot;The coordination of the whole body movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T05:28:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000352 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000352">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000351"/>
+        <nbo:IAO_0000115>&quot;The coordination of the lower body movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T05:30:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper body coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000353 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000353">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000351"/>
+        <nbo:IAO_0000115>&quot;The coordination of the upper body movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T05:30:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lower body coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000354 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000354">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000347"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-05T05:33:26Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bilateral coordination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000355 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000355">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
+        <nbo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the body and its limbs.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T09:30:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">posture</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000356 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000356">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000355"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000309"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000355"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000309"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the body.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T09:30:45Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body posture</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000357 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000357">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000355"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002101"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000355"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002101"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the limbs.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T09:31:06Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">limb posture</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000358 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000358">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000355"/>
+        <nbo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the body and its limbs in inactivity.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T09:31:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">resting posture</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000359 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000359">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+        <nbo:IAO_0000115>&quot;Behavior associated with surface locomotion.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T09:44:37Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">terrestrial locomotory behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000360 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000360">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000366"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the upward thrust produced by the rapid, simultaneous extension of the hind legs with the intend to cross wide gaps in the locomotor surface.&quot; [MBP:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T09:47:57Z</dc:date>
+        <oboInOwl:hasExactSynonym>saltation</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leaping behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000361 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000361">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000342"/>
+        <nbo:IAO_0000115>&quot;The pattern of movement of the limbs of animals, characterized by elements of progression, stability, speed and length over the ground.&quot; [MP:0001406]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T10:07:23Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gait</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000362 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000362">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000361"/>
+        <nbo:IAO_0000115>&quot;A behavioral pattern characterized by the distance covered by as many steps as there are legs.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T10:08:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stride</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000363 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000363">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the movement resulting by dragging the body close to the ground.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T11:39:16Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">crawl</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crawling behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000364 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000364">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000368"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the locomotion of animals in trees.&quot; [wikipedia:Arboreal_locomotion]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T11:40:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arboreal locomotion behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000365 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000365">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000364"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arm over arm swinging movement through arboreal environment [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T11:42:31Z</dc:date>
+        <rdfs:comment>Arguably the epitome of arboreal locomotion, it involves swinging with the arms from one handhold to another.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brachiation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000366 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000366">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the movement of an organism from one location to another through the air.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T11:44:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aerial locomotion behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000367 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000367">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000366"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the self-propelled movement of an organism from one location to another through the air, usually by means of active wing movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T11:45:51Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000072</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym xml:lang="en">fly</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>flying</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0007629</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">flight behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000368 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000368">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the ascending a steep object.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T11:46:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">climbing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000369 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000369">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000366"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the expansion lateral surface of the body with the intention of increasing the wind resistance against the body and hence reducing the speed of falling.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T12:20:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gliding behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000370 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000370">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000016"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the upward thrust produced by the rapid, simultaneous extension of the hind legs with the intend to rise in the air.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T12:25:30Z</dc:date>
+        <oboInOwl:hasExactSynonym>hopping</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saltation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000371 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000371">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the movement of an organism from one location to another through a liquid medium.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T12:33:07Z</dc:date>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swim</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>swimming</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aquatic locomotion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000372 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000372">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the control of the direction of locomotion.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:15:21Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directional control of locomotion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000373 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000373">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000372"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the ability of an animal to determine and to alter its position in the environment.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:16:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotory orientation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000374 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000374">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000373"/>
+        <nbo:IAO_0000115>&quot;Alteration of speed or direction of movement in response to a sensory stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:17:18Z</dc:date>
+        <oboInOwl:xref>GO:0042465</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinesis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000375 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000375">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000373"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in a specific spatial relationship to a stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:17:27Z</dc:date>
+        <oboInOwl:xref>GO:0042330</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">taxis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000376 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000376">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000372"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the mechanical alteration of the locomotor pattern through which the animal adjusts its position.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:18:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">steering behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000377 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000377">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to specific chemical concentration gradient.&quot; [GO:0006935]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:23:34Z</dc:date>
+        <oboInOwl:hasExactSynonym>chemotaxis</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0006935</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemotactic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000378 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000378">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to gravity.&quot; [GO:0048062]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:27:22Z</dc:date>
+        <oboInOwl:hasExactSynonym>geotactic behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>gravitaxis</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0042332</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gravitactic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000379 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000379">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000378"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation away from the source of gravity.&quot; [GO:0048060]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:32:49Z</dc:date>
+        <oboInOwl:hasExactSynonym>negative geotactic behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>negative gravitaxis</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0048060</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">negative gravitactic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000380 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000380">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000378"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation towards the source of gravity.&quot; [GO:0048061]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:34:24Z</dc:date>
+        <oboInOwl:hasExactSynonym>positive geotactic behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>positive gravitaxis</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0048061</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">positive gravitactic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000381 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000381">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000386"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to touch.&quot; [GO:0001966]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:45:18Z</dc:date>
+        <oboInOwl:hasExactSynonym>stereotaxis</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thigmotaxis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000382 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000382">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to physical parameters involved in energy generation.&quot; [GO:0009453]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:47:46Z</dc:date>
+        <oboInOwl:xref>GO:0009453</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">energy taxis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000383 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000383">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000382"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to light.&quot; [GO:0042331]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:48:33Z</dc:date>
+        <oboInOwl:hasExactSynonym>phototaxis</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0042331</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phototactic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000384 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000384">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000382"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to a temperature gradient.&quot; [GO:0043052]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:50:19Z</dc:date>
+        <oboInOwl:xref>GO:0043052</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermotaxis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000385 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000385">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000386"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to sound.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:58:40Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phonotaxis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000386 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000386">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to mechanical stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T01:59:20Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mechanical stimulus taxis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000387 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000387">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000386"/>
+        <nbo:IAO_0000115>&quot;Locomotory orientation in response to pressure.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T02:01:21Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">barotaxis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000388 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000388">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/NBO_0000403"/>
+        <nbo:IAO_0000115>&quot;Behavior related to movements that occur independent of planning.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T02:35:38Z</dc:date>
+        <rdfs:comment>Movevents listed here are involuntary, but may be also generated by free will, like blinking of the eyelids and respiratory movements.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">involuntary movement behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000389 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000389">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000388"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0060004"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000388"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0060004"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to involuntary movement in response to a stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T02:36:55Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000004</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>reflex behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reflexive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000390 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000390">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;Reflex actions originating in the central nervous system that are exhibited by normal infants in response to particular stimuli.&quot; [wikipedia:Primitive_reflexes]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T02:44:15Z</dc:date>
+        <oboInOwl:hasExactSynonym>infant reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>infantile reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>newborn reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">primitive reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000391 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000391">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;An action or movement due to the application of a sudden unexpected stimulus.&quot; [wikipedia:Startle_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T02:55:21Z</dc:date>
+        <oboInOwl:hasExactSynonym>alarm reaction</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">startle reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000392 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000392">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex that arises when tilting the head back while lying on the back causes the back to stiffen and even arch backwards, the legs to straighten, stiffen, and push together, the toes to point, the arms to bend at the elbows and wrists, and the hands to become fisted or the fingers to curl.&quot; [wikipedia:Tonic_labyrinthine_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:03:51Z</dc:date>
+        <oboInOwl:hasExactSynonym>TLR</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tonic labyrinthine reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000393 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000393">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex that assists in the birthing process and helps to develop muscle tone, kicking and stimulates vestibular function in utero.&quot; [wikipedia:Asymmetrical_tonic_neck_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:05:52Z</dc:date>
+        <oboInOwl:hasExactSynonym>ATNR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fencing reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">asymmetrical tonic neck reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000394 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000394">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex that causes the eyes to alternately fixate at far and near, expanding vision development from arms length to far away.&quot; [MBP:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:10:14Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">symmetrical tonic neck reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000395 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000395">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;It is elicited by holding the newborn in ventral suspension (face down) and stroking along the one side of the spine. A reflex that caused the laterally flex toward the stimulated side when a newborn is held in ventral suspension (face down) and stroking along the one side of the spine.&quot; [NBO:Galant_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:11:13Z</dc:date>
+        <oboInOwl:hasExactSynonym>spinal galant</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">galant reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000396 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000396">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex elicited by the application of pressure to both palms resulting varying responses such as head flexion, head rotation or opening of the mouth, or a combination of these responses.&quot; [wikipedia:Primitive_reflexes]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:14:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">babkin reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000397 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000397">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex that causes the infant to begin to paddle and kick in a swimming motion upon its placement face down in a pool of water.&quot; [NBO:Primitive_reflexes]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:15:57Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swimming reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000398 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000398">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A reflex elicited when the sole of the foot is stimulated with a blunt instrument.&quot; [wikipedia:Plantar_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:18:52Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">plantar reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000399 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000399">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex elicited by the placement of an object in the infant&apos;s hand and strokes their palm, causing its fingers to close and grasp it.&quot; [wikipedia:Primitive_reflexes]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:20:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">palmar grasp reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000400 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000400">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex that causes a newborn infant to turn his head toward anything that strokes his cheek or mouth, searching for the object by moving his head in steadily decreasing arcs until the object is found.&quot; [wikipedia:Primitive_reflexes]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:22:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rooting reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000401 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000401">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000054"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex that causes the infant to instinctively suck at anything that touches the roof of their mouth and suddenly starts to suck simulating the way they naturally eat.&quot; [wikipedia:Primitive_reflexes]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:25:21Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sucking reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000402 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000402">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex that causes the infant to attempt to &apos;walk&apos; by placing one foot in front of the other when the soles of their feet touch a flat surface.&quot; [wikipedia:Primitive_reflexes]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:26:47Z</dc:date>
+        <oboInOwl:hasExactSynonym>stepping reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">walking reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000403 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000403">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050882"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:IAO_0000115>&quot;Behavior related to movements executed with intent.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T03:32:28Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">voluntary movement behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000404 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000404">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A muscle contraction in response to stretching within the muscle.&quot; [wikipedia:Stretch_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:02:17Z</dc:date>
+        <oboInOwl:hasExactSynonym>deep tendon reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stretch reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000405 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000405">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A deep tendon reflex that elicits involuntary contraction of the biceps brachii muscle.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:06:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biceps reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000406 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000406">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A deep tendon reflex elicited by striking the lateral surface of the forearm proximal to the distal head of the radius, characterized by normal slight elbow flexion and forearm supination.&quot; [Medical disctionary:http\://medical-dictionary.thefreedictionary.com/brachioradialis+reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:07:37Z</dc:date>
+        <oboInOwl:hasExactSynonym>supinator reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brachioradialis reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000407 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000407">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A reflex that elicits involuntary contraction of the extensor digitorum muscle.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:09:37Z</dc:date>
+        <oboInOwl:hasExactSynonym>BER</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Braunecker-Effenberg reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">extensor digitorum reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000408 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000408">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A deep tendon reflex that elicits involuntary contraction of the triceps brachii muscle.&quot; [wikipedia:Triceps_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:12:22Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">triceps reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000409 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000409">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A deep tendon reflex that elicits extension of the leg resulting from a sharp tap on the patellar tendon.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:18:23Z</dc:date>
+        <oboInOwl:hasExactSynonym>knee-jerk reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">patellar reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000410 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000410">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A reflex bending of the foot resulting from contraction of the calf muscles when the Achilles tendon is sharply struck.&quot; [Medical Dictionary:http\://medical-dictionary.thefreedictionary.com/Achilles+reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:20:42Z</dc:date>
+        <oboInOwl:hasExactSynonym>Achilles reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Achilles tendon reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ankle reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>triceps surae reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ankle jerk reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000411 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000411">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex that involves cranial nerves.&quot; [wikipedia:Reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:28:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cranial nerve related reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000412 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000412">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
+        <nbo:IAO_0000115>&quot;A reflex that controls the diameter of the pupil, in response to the intensity (luminance) of light that falls on the retina of the eye, thereby assisting in adaptation to various levels of darkness and light, in addition to retinal sensitivity.&quot; [wikipedia:Pupillary_light_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:28:58Z</dc:date>
+        <oboInOwl:hasExactSynonym>pupillary reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pupillary light reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000413 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000413">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
+        <nbo:IAO_0000115>&quot;A reflex action of the eye, in response to focusing on a near object, then looking at distant object (and vice versa), comprising coordinated changes in vergence, lens shape and pupil size.&quot; [wikipedia:Accommodation_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:29:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">accommodation reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000414 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000414">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T04:30:58Z</dc:date>
+        <oboInOwl:hasExactSynonym>masseter reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jaw jerk reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000415 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000415">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
+        <nbo:IAO_0000115>&quot;An involuntary blinking of the eyelids elicited by stimulation of the cornea.&quot; [wikipedia:Corneal_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T06:08:06Z</dc:date>
+        <oboInOwl:hasExactSynonym>blink reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>blinking</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">corneal reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000416 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000416">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
+        <nbo:IAO_0000115>&quot;A reflex eye movement that stabilizes images on the retina during head movement by producing an eye movement in the direction opposite to head movement, thus preserving the image on the center of the visual field.&quot; [wikipedia:Vestibulo-ocular_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T06:11:09Z</dc:date>
+        <oboInOwl:hasExactSynonym>VOR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>oculovestibular reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>vestibuloocular reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibulo-ocular reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000417 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000417">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000416"/>
+        <nbo:IAO_0000115>&quot;A form of involuntary eye movement that is part of the vestibulo-ocular reflex (VOR). It is characterized by alternating smooth pursuit in one direction and saccadic movement in the other direction.&quot; [wikipedia:Physiologic_nystagmus]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T06:16:20Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">physiologic nystagmus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000418 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000418">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
+        <nbo:IAO_0000115>&quot;A reflex contraction of the back of the throat, evoked by touching the soft palate.&quot; [wikipedia:Gag_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-06T06:17:32Z</dc:date>
+        <oboInOwl:hasExactSynonym>gag reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>swallowing reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pharyngeal reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000419 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000419">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000024"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000473"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the readily reversible state of reduced awareness and metabolic activity that occurs periodically in many animals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T01:19:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleeping behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000420 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000420">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
+        <nbo:IAO_0000115>&quot;A NREM parasomnia characterised by Involuntarily grinding of teeth while sleeping.&quot; [MBP:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T01:20:00Z</dc:date>
+        <oboInOwl:hasExactSynonym>&lt;new synonym&gt;</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>teeth grinding</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0003763</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bruxism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000421 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000421">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
+        <nbo:IAO_0000115>&quot;A circadian rhythm sleep disorder characterized by a much later than normal timing of sleep onset and offset and a period of peak alertness in the middle of the night.&quot; [wikipedia:Delayed_sleep_phase_syndrome]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T01:22:32Z</dc:date>
+        <oboInOwl:hasExactSynonym>DSPS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>delayed sleep-phase disorder (DSPD)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>delayed sleep-phase type (DSPT)</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delayed sleep phase syndrome</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000422 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000422">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
+        <nbo:IAO_0000115>&quot;Inability to fall asleep and/or remain asleep for a reasonable amount of time.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T01:23:24Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000423 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000423">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
+        <nbo:IAO_0000115>&quot;A dyssomnia characterised by excessive daytime sleepiness (EDS) in which a person experiences extreme fatigue and possibly falls asleep at inappropriate times.&quot; [wikipedia:Narcolepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T01:24:10Z</dc:date>
+        <oboInOwl:xref>MP:0005279</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">narcolepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000424 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000424">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
+        <nbo:IAO_0000115>&quot;A NREM parasomnia characterised by abrupt awakening from sleep with behavior consistent with terror and a temporary inability to regain full consciousness.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T01:25:22Z</dc:date>
+        <oboInOwl:hasExactSynonym>Pavor nocturnus</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>night terror</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep terror</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000425 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000425">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex that results in the contraction of the muscles of the abdominal wall in response to stimulation of the overlying skin.&quot; [web:http\://www.merriam-webster.com/medical/abdominal%20reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:12:21Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdominal reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000426 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000426">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;Reflexive contraction of the external anal sphincter upon stroking of the skin around the anus.&quot; [wikipedia:Anal_wink]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:12:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>anal reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>anal wink</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>perineal reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anocutaneous reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000427 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000427">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex is elicited by lightly stroking the superior and medial (inner) part of the thigh resulting in a contraction of the cremaster muscle that pulls up the scrotum and testis on the side stroked.&quot; [wikipedia:Cremasteric_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:15:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cremasteric reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000428 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000428">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex in mammals which optimises respiration to allow staying underwater for extended periods of time.&quot; [wikipedia:Mammalian_diving_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:16:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mammalian diving reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000429 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000429">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000425"/>
+        <nbo:IAO_0000115>&quot;An increase in tonus (normal tension) of the tissues of the abdominal muscles resulting from painful stimuli originating in a viscus.&quot; [:http\://www.wordinfo.info/words/index/inf]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:18:30Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visceromotor reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000430 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000430">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000429"/>
+        <nbo:IAO_0000115>&quot;A reflex of the abdominal muscles to contract upon mechanical force to the abdomen, and serves as protection.&quot; [wikipedia:Muscular_defense]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:20:21Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">muscular defense</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000431 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000431">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000057"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A response to activation of sensory neurons whose peripheral terminals are located on the surface of the body.&quot; [wikipedia:Scratch_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:21:15Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000021</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>self-scratching</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scratch reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000432 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000432">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000391"/>
+        <nbo:IAO_0000115>&quot;An action or movement due to the application of a sudden unexpected loud noise.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:31:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acoustic startle reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000433 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000433">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
+        <nbo:IAO_0000115>&quot;A reflex where the body reacts to pain or unpleasant stimuli by trying to move itself away from the source.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:35:05Z</dc:date>
+        <oboInOwl:hasExactSynonym>flexor withdrawal reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nociceptive reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">withdrawal reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000434 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000434">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000433"/>
+        <nbo:IAO_0000115>&quot;A reflex where the flexors in the withdrawing limb contract and the extensors relax, while in the other limb, the opposite occurs.&quot; [wikipedia:Crossed_extensor_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:39:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crossed extensor reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000435 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000435">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;An involuntary muscle contraction that occurs in the middle ear of mammals in response to high-intensity sound stimuli.&quot; [wikipedia:Acoustic_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:41:07Z</dc:date>
+        <oboInOwl:hasExactSynonym>attenuation reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>auditory reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>stapedius reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acoustic reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000436 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000436">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex in which joint movement can reflexively cause muscle activation or inhibition.&quot; [wikpedia:Arthrokinetic_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:42:50Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arthrokinetic reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000437 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000437">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex by which the body rids the lower respiratory tract of any irritant that enters through the air and less frequently any fluids (drinks) and solids (food) that may spill into the respiratory tract.&quot; [XX:http\://www.healthhype.com/cough-reflex-physiology-process-ear-cough-reflexes.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:45:22Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cough reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000438 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000438">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A pouting or pursing of the lips that is elicited by light tapping of the closed lips near the midline.&quot; [wikipedia:Snout_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:47:28Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snout reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000439 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000439">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
+        <nbo:IAO_0000115>&quot;A reflex elicited by repetitive tapping on the forehead which result in blinking to the first several taps.&quot; [wikipedia:Glabellar_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-07T05:48:07Z</dc:date>
+        <oboInOwl:hasExactSynonym>glabellar tap sign</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glabellar reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000440 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000440">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A skeletal muscle contraction causes the muscle to simultaneously lengthen and relax.&quot; [wikipedia:Golgi_tendon_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:01:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>inverse myotatic reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Golgi tendon reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000441 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000441">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex in which muscle groups around the vital organs begin to shake in small movements in an attempt to create warmth by expending energy.&quot; [wikipedia:Shivering]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:05:40Z</dc:date>
+        <rdfs:comment>The shivering reflex is triggered to maintain homeostasis.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shivering reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000442 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000442">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex in which mucus containing foreign particles or irritants is expelled and the nasal cavity is cleanses.&quot; [wikipedia:Sneeze]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:08:31Z</dc:date>
+        <oboInOwl:hasExactSynonym>sneeze</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sneezing</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sternutation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000443 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000443">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A contraction of muscles in the gastrointestinal tract in response to distension of the tract following consumption of food and drink.&quot; [wikipedia:Vagus_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:10:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vagovagal reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000444 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000444">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:22:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000445 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000445">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:22:13Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tail movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000446 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000446">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007601"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:IAO_0000115>&quot;Selectively track a moving object.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:25:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual pursuit</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000447 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000447">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_00000050"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>Activation of locomotory behavior.</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:27:51Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotor activation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000448 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000448">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:28:10Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vertical activity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000449 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000449">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
+        <nbo:IAO_0000115>Kinesthetic behavior initiated in the absence of specific sensory input.</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:28:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spontaneous movement behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000450 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000450">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the activity in which individuals in a group clean or maintain one another&apos;s body or appearance.&quot; [wikipedia:Social_grooming]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:35:02Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">allo-hygiene behavior</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>allogrooming</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">allohygiene</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social grooming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000451 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000451">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the promotion of personal hygiene.&quot; [wikipedia:Social_grooming]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:35:54Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000058</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>auto-grooming</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">autohygiene</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>preening</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>self-grooming</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">personal grooming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000452 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000452">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000065"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the state or ability to perceive, to feel, or to be conscious of events, objects or sensory patterns.&quot; [wikipedia:Awareness]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:50:34Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">awareness</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000453 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000453">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000065"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T12:52:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior related to feelings experiencing</rdfs:label>
+        <owl:deprecated>true</owl:deprecated>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000455 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000455">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:IAO_0000115>&quot;The sustained focus of cognitive resources on information while filtering or ignoring extraneous information.  Intended to encompass only attention to perceptual stimuli. &quot; [wikipedia:Attention]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:02:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">attention behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000456 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000456">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
+        <nbo:IAO_0000115>&quot;Behavior involving responding discretely to specific visual, auditory or tactile stimuli.&quot; [wikipedia:Attention]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:04:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">focused attention behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000457 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000457">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
+        <nbo:IAO_0000115>&quot;Behavior involving maintaining a behavioral or cognitive set in the face of distracting or competing stimuli.&quot; [wikipedia:Attention]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:05:54Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">selective attention behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000458 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000458">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
+        <nbo:IAO_0000115>&quot;Behavior involving mental flexibility that allows individuals to shift their focus of attention and move between tasks having different cognitive requirements.&quot; [wikipedia:Attention]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:05:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alternating attention behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000459 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000459">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
+        <nbo:IAO_0000115>&quot;Behavior involving maintaining a consistent behavioral response during continuous and repetitive activity.&quot; [wikipedia:Attention]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:06:00Z</dc:date>
+        <oboInOwl:hasExactSynonym>vigilance</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sustained attention behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000460 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000460">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
+        <nbo:IAO_0000115>&quot;Behavior involving responding simultaneously to multiple tasks or multiple task demands.&quot; [wikipedia:Attention]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:08:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">divided attention behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000461 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000461">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000225"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000117"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000225"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000746"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000117"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;The perception of familiar objects as approximately the same size regardless of their distance from the observer.&quot; [Jrank:http\://science.jrank.org/pages/5094/Perception.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:15:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">size constancy behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000462 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000462">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000225"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000014"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000225"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000014"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;The perception of a color as constant under changing conditions of illumination.&quot; [wikipedia:Color_constancy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:16:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">colour constancy behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000463 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000463">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000225"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000225"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000465"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;The perception of familiar objects as approximately the same shape regardless of their distance or angle of view from the observer.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:18:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shape constancy behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000464 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000464">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:IAO_0000115>&quot;Perception relating to the process of inferring the speed and direction of elements in a scene based on visual, vestibular and proprioceptive inputs.&quot; [wikipedia:Motion_perception]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:23:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perception of motion behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000465 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000465">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000308"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Perception related to the identification of objects and their distinction from each other.&quot; [:http\://science.jrank.org/pages/5094/Perception.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:25:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">form perception behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000466 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000466">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000308"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001595"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000746"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001595"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior involving an active reception and coordination of information relating to depth received through the sensory systems in order to perceive the three-dimensionality of the world and objects within it.&quot; [:erceiving the three-dimensionality of the world and objects  Read more\: Perception - Perceptual Systems\, Historical Background\, Innate And Learned - Classical perceptual phenomena\, Broad theoretical approaches\, Current research/future developments http\://science.jrank.org/pages/5094/Perception.html#ixzz1It3oOobp]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:29:05Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">depth perception behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000467 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000467">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000746"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000040"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000746"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000040"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Perception of the distance of an object.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:31:08Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">distance perception behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000468 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000468">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:IAO_0000115>&quot;Misperception of stimuli, where what is perceived does not correspond to the actual dimensions or qualities of the physical stimulus.&quot; [jrank:http\://science.jrank.org/pages/5094/Perception.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:32:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perceptual illusion behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000469 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000469">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Behavior related to how the body reacts to a stressor ( a stimulus that causes stress), real or imagined.&quot; [wikipedia:Stress_(biological)]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:52:36Z</dc:date>
+        <rdfs:comment>It refers to the consequence of the failure of an organism to respond adequately to mental, emotional or physical demands, whether actual or imagined.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stress related behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000470 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000470">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the identification or realization of a threat or a stressor.&quot; [wikipedia:Stress_(biological)]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T01:55:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral alarm</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000471 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000471">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000088"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000127"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:00:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">predator avoidance behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000472 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000472">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the depletion of the body resources for coping to stress.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:06:24Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral exhaustion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000473 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000473">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000008"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:18:40Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhythmic behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000474 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000474">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0048512"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000473"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:19:42Z</dc:date>
+        <oboInOwl:hasExactSynonym>pathological circadian behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000475 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000475">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
+        <nbo:IAO_0000115>&quot;A pathological sleeping behavior related to the initiating or maintaining sleep or of excessive sleepiness and are characterized by a disturbance in the amount, quality, or timing of sleep.&quot; [wikipedia:Dyssomnia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:20:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dyssomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000476 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000476">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:21:57Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intrinsic sleep disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000477 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000477">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
+        <nbo:IAO_0000115>&quot;A dyssomnia characterized by excessive amounts of sleepiness.&quot; [wikipedia:Hypersomnia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:26:26Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypersomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000478 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000478">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
+        <nbo:IAO_0000115>&quot;A dyssomnia where the patient moves limbs involuntarily during sleep, and has symptoms or problems related to the movement.&quot; [wikipedia:Periodic_limb_movement_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:27:28Z</dc:date>
+        <oboInOwl:hasExactSynonym>PLMD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nocturnal myoclonus</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">periodic limb movement disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000479 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000479">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
+        <nbo:IAO_0000115>&quot;A dyssomnia characterized by an irresistible urge to move one&apos;s body to stop uncomfortable or odd sensations.&quot; [wikipedia:Restless_legs_syndrome]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:28:45Z</dc:date>
+        <oboInOwl:hasExactSynonym>RLS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Wittmaack Ekbom syndrome</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">restless legs syndrome</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000480 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000480">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000494"/>
+        <nbo:IAO_0000115>&quot;A sleep breathing disorder characterized by abnormal pauses in breathing or instances of abnormally low breathing, during sleep.&quot; [wikipedia:Sleep_apnea]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:30:29Z</dc:date>
+        <oboInOwl:hasExactSynonym>sleep apnoea</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep apnea</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000481 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000481">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
+        <nbo:IAO_0000115>&quot;A dyssomnia characterized by a mistakenly perception of one&apos;s sleep as wakefulness.&quot; [wikipedia:Sleep_state_misperception]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:31:33Z</dc:date>
+        <oboInOwl:hasExactSynonym>SSM</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>paradoxical insomnia</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pseudo-insomnia</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sleep hypochondriasis</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>subjective insomnia</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>subjective sleepiness</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep state misperception</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000482 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000482">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:35:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">extrinsic sleep disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000483 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000483">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000482"/>
+        <nbo:IAO_0000115>&quot;A dyssomnia associated with alcohol intake.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:36:22Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol-dependent sleep disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000484 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000484">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000482"/>
+        <nbo:IAO_0000115>&quot;A insomnia associated with food allergies.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:37:51Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food allergy insomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000485 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000485">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000474"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
+        <nbo:IAO_0000115>&quot;A pathological circadian behavior primarily related to the timing of sleep.&quot; [wikipedia:Circadian_rhythm_sleep_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:38:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian rhythm sleep disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000486 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000486">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000485"/>
+        <nbo:IAO_0000115>&quot;An extrinsic circadian rhythm sleep disorder characterized by insomnia and excessive sleepiness affecting people whose work hours are scheduled during the typical sleep period.&quot; [wikipedia:Shift_work_sleep_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:54:21Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">extrinsic circadian rhythm sleep disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000487 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000487">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000485"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:54:52Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intrinsic circadian rhythm sleep disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000488 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000488">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000486"/>
+        <nbo:IAO_0000115>&quot;An extrinsic circadian rhythm sleep disorder resulting from rapid long distance transmeridian (east west or west east) travel.&quot; [wikipedia:Jet_lag]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:55:50Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jet lag</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000489 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000489">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000486"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T02:57:20Z</dc:date>
+        <oboInOwl:hasExactSynonym>SWSD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shift work sleep disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000490 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000490">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
+        <nbo:IAO_0000115>&quot;A circadian rhythm sleep disorder characterized by difficulty staying awake in the evening and staying asleep in the morning.&quot; [wikipedia:Advanced_sleep_phase_syndrome]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:00:14Z</dc:date>
+        <oboInOwl:hasExactSynonym>ASPS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>ASPT</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>advanced sleep-phase type</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">advanced sleep phase syndrome</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000491 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000491">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
+        <nbo:IAO_0000115>&quot;A circadian rhythm sleep disorder which the affected individual&apos;s sleep occurs later and later each day, with the period of peak alertness also continuously moving around the clock from day to day.&quot; [wikipedia:Circadian_rhythm_sleep_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:11:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>circadian rhythm sleep disorder, free running type</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>circadian rhythm sleep disorder, nonentrained type</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>free running disorder (FRD)</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>hypernychthemeral syndrome</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>non-24</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>non-24-hour circadian rhythm disorder</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>non-24-hour sleep-wake disorder</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-24-hour sleep-wake syndrome</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000492 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000492">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
+        <nbo:IAO_0000115>&quot;A circadian rhythm sleep disorder characterized by numerous naps throughout the 24-hour period, no main night time sleep episode and irregularity from day to day.&quot; [wikipedia:Irregular_sleep-wake_rhythm]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:16:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">irregular sleep-wake rhythm</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000493 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000493">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
+        <nbo:IAO_0000115>&quot;A sleeping behavior phenotype that involve abnormal and unnatural movements, emotions, perceptions, and dreams that occur while falling asleep, sleeping, between sleep stages, or during arousal from sleep.&quot; [wikipedia:Parasomnia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:20:06Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">parasomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000494 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000494">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
+        <nbo:IAO_0000115>&quot;An intrinsic sleep disorder characterised by breathing abnormalities.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:27:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>SBD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep breathing disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000495 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000495">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000024"/>
+        <nbo:IAO_0000115>&quot;A sleeping behavior characterised by vibration of respiratory structures and the resulting sound, due to obstructed air movement during breathing while sleeping.&quot; [wikipedia:Snoring]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:28:23Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snoring</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000496 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000496">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000494"/>
+        <nbo:IAO_0000115>&quot;A sleep breathing disorder characterized by airway resistance to breathing during sleep.&quot; [wikipedia:Upper_airway_resistance_syndrome]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:30:24Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper airway resistance syndrome</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000497 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000497">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000477"/>
+        <nbo:IAO_0000115>&quot;A hypersomnia characterized by recurrent episodes.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:32:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recurrent hypersomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000498 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000498">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000477"/>
+        <nbo:IAO_0000115>&quot;A hypersomnia that occurs as a result of a traumatic event involving the central nervous system.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:32:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">posttraumatic hypersomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000499 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000499">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000493"/>
+        <nbo:IAO_0000115>&quot;A type of parasomnia that occurs during NREM sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-08T03:37:10Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NREM parasomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000500 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000500">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
+        <nbo:IAO_0000115>&quot;A NREM parasomnia characterised by the risef rom the slow wave sleep stage in a state of low consciousness and perform activities that are usually performed during a state of full consciousness.&quot; [wikipedia:Sleepwalking]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T09:32:07Z</dc:date>
+        <oboInOwl:hasExactSynonym>somnambulism</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleepwalking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000501 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000501">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
+        <nbo:IAO_0000115>&quot;A NREM parasomnia characterised by involuntary urination while asleep after the age at which bladder control usually occurs.&quot; [wikipedia:Bedwetting]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T09:39:54Z</dc:date>
+        <oboInOwl:hasExactSynonym>bedwetting</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nocturnal enuresis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000502 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000502">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
+        <nbo:IAO_0000115>&quot;A NREM parasomnia characterised by talking during sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:02:28Z</dc:date>
+        <oboInOwl:hasExactSynonym>sleep-talking</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somniloquy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000503 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000503">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000504"/>
+        <nbo:IAO_0000115>&quot;A REM parasomnia characterised by the lack of muscle atonia during sleep.&quot; [wikipedia:REM_Sleep_Behavior_Disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:06:44Z</dc:date>
+        <oboInOwl:hasExactSynonym>RBD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM sleep behavior disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000504 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000504">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000493"/>
+        <nbo:IAO_0000115>&quot;A type of parasomnia that occurs during REM sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:07:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM parasomnia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000505 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000505">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000503"/>
+        <nbo:IAO_0000115>&quot;A RBD that occurs mostly as a result of a side-effect in prescribed medication- usually antidepressants.&quot; [wikipedia:Parasomnia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:10:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acute RBD</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000506 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000506">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000503"/>
+        <nbo:IAO_0000115>&quot;Idiopathic or associated with neurological disorders REM sleep behavior disorder.&quot; [wikipedia:Parasomnia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:11:32Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chronic RBD</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000507 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000507">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000504"/>
+        <nbo:IAO_0000115>&quot;A REM parasomnia consisting of breath holding and expiratory groaning during sleep that is distinct from both somniloquy and obstructive sleep apnea.&quot; [wikipedia:Catathrenia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:13:44Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catathrenia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000508 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000508">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000509"/>
+        <nbo:IAO_0000115>&quot;An isolted sleep paralysis that is characterized by frequent episodes or a complex of sequential episodes whose total duration may exceed one hour, and particularly by the range and sense of perceived reality of the subjective phenomena experienced during episodes.&quot; [web:http\://www.theconsciousdreamer.org/SSE.HTM]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:14:54Z</dc:date>
+        <oboInOwl:hasExactSynonym>RISP</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recurrent isolated sleep paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000509 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000509">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000510"/>
+        <nbo:IAO_0000115>&quot;A sleep paralaysis characterised by the absence of narcolepsy.&quot; [wikipedia:Sleep_paralysis]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:20:09Z</dc:date>
+        <oboInOwl:hasExactSynonym>ISP</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">isolated sleep paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000510 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000510">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000504"/>
+        <nbo:IAO_0000115>&quot;A REM parasomnia characterised by periods of inability to perform voluntary movements either when going to sleep or when waking up.&quot; [wikipedia:Sleep_paralysis]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:24:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000511 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000511">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000510"/>
+        <nbo:IAO_0000115>&quot;A sleep paralysis which upon falling asleep the person remains aware while the body shuts down for REM sleep.&quot; [wikipedia:Sleep_paralysis]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:25:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>predormital sleep paralysis</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypnagogic sleep paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000512 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000512">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000510"/>
+        <nbo:IAO_0000115>&quot;A sleep paralysis which upon awakening, the person becomes aware before the REM cycle is complete,.&quot; [wikipedia:Sleep_paralysis]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:28:53Z</dc:date>
+        <oboInOwl:hasExactSynonym>postdormital sleep paralysis</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypnopompic sleep paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000513 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000513">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000368"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the ascending stairs.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T10:51:13Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">climbing stairs</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000514 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000514">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
+        <nbo:IAO_0000115>&quot;A dyssomnia characterised by fear of sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T11:20:26Z</dc:date>
+        <oboInOwl:hasExactSynonym>somniphobia</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypnophobia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000515 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000515">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0002361"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000085"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000256"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-09T12:28:31Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000523</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>DD-NOS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>depressive disorder not otherwise specified</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0000716</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">depressive disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000516 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000516">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
+        <nbo:IAO_0000115>&quot;A major depressive disorder characterized by mood reactivity (paradoxical anhedonia) and positivity, significant weight gain or increased appetite (\&quot;comfort eating\&quot;), excessive sleep or somnolence (hypersomnia), a sensation of heaviness in limbs known as leaden paralysis, and significant social impairment as a consequence of hypersensitivity to perceived interpersonal rejection.&quot; [wikipedia:Atypical_depression]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T12:55:14Z</dc:date>
+        <oboInOwl:hasExactSynonym>AD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atypical depression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000517 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000517">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
+        <nbo:IAO_0000115>&quot;A major depressive disorder characterized by a loss of pleasure (anhedonia) in most or all activities, a failure of reactivity to pleasurable stimuli, a quality of depressed mood more pronounced than that of grief or loss, a worsening of symptoms in the morning hours, early morning waking, psychomotor retardation, excessive weight loss (not to be confused with anorexia nervosa), or excessive guilt.&quot; [wikipedia:Melancholic_depression]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T12:57:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">melancholic depression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000518 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000518">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
+        <nbo:IAO_0000115>&quot;A major depressive disorder characterized by a major depressive episode, particularly of melancholic nature, where the patient experiences psychotic symptoms such as delusions or, less commonly, hallucinations.&quot; [wikipedia:Psychotic_major_depression]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T12:58:44Z</dc:date>
+        <oboInOwl:hasExactSynonym>PMD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">psychotic major depression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000519 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000519">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
+        <nbo:IAO_0000115>&quot;A major depressive disorder characterized by psychological and motorological disturbances.&quot; [wikipedia:Catatonia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:01:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catatonic depression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000520 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000520">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
+        <nbo:IAO_0000115>&quot;A major depressive disorder characterized by a intense, sustained and sometimes disabling depression experienced by women after giving birth.&quot; [wikipedia:Postpartum_depression]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:03:17Z</dc:date>
+        <oboInOwl:hasExactSynonym>PDD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>postnatal depression</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">postpartum depression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000521 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000521">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
+        <nbo:IAO_0000115>&quot;A major depressive disorder usually characterized seasonal pattern with depressive episodes coming on in the winter or summer, spring or autumn, repeatedly, year after year.&quot; [wikipedia:Seasonal_affective_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:10:46Z</dc:date>
+        <oboInOwl:hasExactSynonym>winter blues</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>winter depression</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">seasonal affective disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000522 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000522">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
+        <nbo:IAO_0000115>&quot;A depressive disorder characterized by chronic, different mood disturbance.&quot; [wikipedia:Dysthymia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:13:55Z</dc:date>
+        <rdfs:comment>For humans: where a person reports a low mood almost daily over a span of at least two years.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dysthymia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000524 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000524">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
+        <nbo:IAO_0000115>&quot;A depressive disorder characterized by intermittent depressive episodes, in women not related to menstrual cycles, occurring at least once a month over at least one year or more fulfilling the diagnostic criteria for major depressive episodes except for duration which in RBD is less than 14 days, typically 2 to 4 days.&quot; [wikipedia:Recurrent_brief_depression]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:17:54Z</dc:date>
+        <oboInOwl:hasExactSynonym>RBD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recurrent brief depression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000525 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000525">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
+        <nbo:IAO_0000115>&quot;A depressive disorder that does not meet full criteria for Major depressive disorder but in which at least two depressive symptoms are present for two weeks.&quot; [wikipedia:Minor_Depressive_Disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:19:53Z</dc:date>
+        <oboInOwl:hasExactSynonym>minor depression</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">minor depressive disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000526 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000526">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
+        <nbo:IAO_0000115>&quot;A type of bipolar disorder distinguished by the presence or history of one or more manic episodes or mixed episodes with or without major depressive episodes.&quot; [wikipedia:Bipolar_I]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:25:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bipolar I</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000527 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000527">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
+        <nbo:IAO_0000115>&quot;A bipolar disorder characterised by recurrent intermittent hypomanic and depressive episodes.&quot; [wikipedia:Mood_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:26:32Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bipolar II</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000528 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000528">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
+        <nbo:IAO_0000115>&quot;A bipolar disorder characterised by recurrent hypomanic and dysthymic episodes, but no full manic episodes or full major depressive episodes.&quot; [wikipedia:Cyclothymia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:27:37Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cyclothymia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000529 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000529">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
+        <nbo:IAO_0000115>&quot;A bipolar disorder characterised by symptoms in the bipolar spectrum (e.g. manic and depressive symptoms) but does not fully qualify for any of the three types of bipolar disorder.&quot; [wikipedia:Bipolar_Disorder_Not_Otherwise_Specified]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:28:33Z</dc:date>
+        <oboInOwl:hasExactSynonym>BD-NOS</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bipolar disorder not otherwise specified</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000530 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000530">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000256"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:33:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">substance induced mood disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000531 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000531">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000530"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:34:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol induced mood disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000532 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000532">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000530"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:34:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">benzodiazepine induced mood disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000533 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000533">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000530"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:34:41Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon-alpha induced mood disorder</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000534 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000534">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
+        <nbo:IAO_0000115>&quot;A pathological anxiety which results from a traumatic experience.&quot; [wikipedia:Post-traumatic_stress_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:42:56Z</dc:date>
+        <oboInOwl:hasExactSynonym>PTSD</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>post-traumatic stress disorder</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">post-traumatic stress</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000535 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000535">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
+        <nbo:IAO_0000115>&quot;A pathological anxiety characterized by feeling of excessive and inappropriate levels of anxiety over being separated from a person or place.&quot; [wikipedia:Separation_anxiety_disorder]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T01:44:22Z</dc:date>
+        <oboInOwl:hasExactSynonym>SepAD</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">separation anxiety</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000536 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000536">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
+        <nbo:IAO_0000115>&quot;Any process in which an organism modulates its heart rate at different values with a regularity of approximately 24 hours.&quot; [GOC:rl]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T02:18:47Z</dc:date>
+        <oboInOwl:xref>GO:0003053</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian regulation of heart rate</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000537 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000537">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
+        <nbo:IAO_0000115>&quot;Any process in which an organism modulates its blood pressure at different values with a regularity of approximately 24 hours.&quot; [GO:GO\:0003052]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T02:21:01Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian regulation of systemic arterial blood pressure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000538 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000538">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000051"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
+        <nbo:IAO_0000115>&quot;Any homeostatic process in which an organism modulates its internal body temperature at different values with a regularity of approximately 24 hours.&quot; [GOC:dbh]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T02:22:58Z</dc:date>
+        <oboInOwl:hasExactSynonym>circadian thermoregulation</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian temperature homeostasis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000539 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000539">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042755"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000270"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">&quot;Observable characteristic of feeding behavior that relates to eating.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:39:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>eating disorder</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eating behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000540 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000540">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042756"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000270"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">&quot;Observable characteristic of feeding behavior that relates to drinking.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:40:49Z</dc:date>
+        <oboInOwl:hasExactSynonym>drinking disorder</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pathological drinking behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drinking behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000541 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000541">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000380"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#qualifier"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001863"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000961"/>
+        <nbo:IAO_0000115>&quot;A pathological drinking behavior characterised by an excessive desire to drink.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:note>&apos;participates in&apos; some 
+(&apos;regulation of drinking behavior&apos; and (has_quality some 
+(&apos;increased frequency&apos; and towards some &apos;liquid consumption&apos; and owl:qualifier some chronic)))</oboInOwl:note>
+        <oboInOwl:xref>MP:0002119</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dipsosis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000542 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000542">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                    </owl:Restriction>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has-input"/>
+                                        <owl:someValuesFrom>
+                                            <owl:Class>
+                                                <owl:intersectionOf rdf:parseType="Collection">
+                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                                                    <owl:Restriction>
+                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001563"/>
+                                                    </owl:Restriction>
+                                                </owl:intersectionOf>
+                                            </owl:Class>
+                                        </owl:someValuesFrom>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#qualifier"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001333"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000540"/>
+        <nbo:IAO_0000115>&quot;A pathological drinking behavior characterised by large intake of fluids by mouth, usually due to excessive thirst that is relatively prolonged.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:note>&apos;participates in&apos; some (
+&apos;regulation of drinking behavior&apos; and regulates some 
+  (&apos;liquid consumption&apos; and has-input some (&apos;liquid substance&apos; and has_quality some &apos;increased mass&apos;)) 
+and 
+owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
+        <oboInOwl:xref>HP:0001959</oboInOwl:xref>
+        <oboInOwl:xref>MP:0001426</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">polydipsia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000543 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000543">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000380"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#qualifier"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001333"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000961"/>
+        <nbo:IAO_0000115>&quot;A pathological drinking behavior characterised by an excessive relative temporal desire to drink.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:note>&apos;participates in&apos; some 
+(&apos;regulation of drinking behavior&apos; and (has_quality some 
+(&apos;increased frequency&apos; and (towards some &apos;liquid consumption&apos;) and (owl:qualifier some &apos;temporally extended&apos;))))</oboInOwl:note>
+        <oboInOwl:xref>MP:0005111</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hyperdipsia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000544 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000544">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001558"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0042755"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
+        <nbo:IAO_0000115>&quot;A pathological feeding behavior characterised by failure to eat.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:xref>MP:0001438</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aphagia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000545 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000545">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0007631"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving food from the mouth cavity to the esophagus through coordinated muscular movements [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:39:39Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">swallow</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swallowing</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000546 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000546">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000134"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000912"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
+        <nbo:IAO_0000115>&quot;A pathological eating behavior characterised by an abnormally large intake of food by mouth, usually due to excessive hunger that is relatively prolonged.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:hasExactSynonym>hyperphagia</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0000724</oboInOwl:xref>
+        <oboInOwl:xref>MP:0001433</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">polyphagia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000547 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000547">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001558"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000230"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000522"/>
+        <nbo:IAO_0000115>&quot;Lack of ability to enjoy a sense of pleasure.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:xref>MP:0009710</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anhedonia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000548 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000548">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
+        <nbo:IAO_0000115>&quot;Behaviour related to the male activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male sexual activity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000549 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000549">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
+        <nbo:IAO_0000115>&quot;Behaviour related to the female activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female sexual activity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000550 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000550">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
+        <nbo:IAO_0000115>&quot;Ability to correctly remember something that has been encountered before.&quot; [wikipedia:Recognition_memory]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:53:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recognition memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000551 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000551">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000550"/>
+        <nbo:IAO_0000115>&quot;Ability to perceive the physical properties of an object (such as shape, colour and texture) and apply semantic attributes to the object, which includes the understanding of its use, previous experience with the object and how it relates to others.&quot; [wikipedia:Cognitive_Neuroscience_of_Visual_Object_Recognition]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:56:14Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual object recognition</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000552 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000552">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000551"/>
+        <nbo:IAO_0000115>&quot;A visual object recognition that lasts hours to months and critically depends on a transfer of the information from short term object recognition memory using repeated rehearsals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T02:02:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term object recognition memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000553 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000553">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000554"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T02:03:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term object recognition memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000554 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000554">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000180"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T02:09:28Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual short term memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000555 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000555">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000180"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000556"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T02:10:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial working memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000556 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000556">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
+        <nbo:IAO_0000115>&quot;A type of memory responsible for recording information about one&apos;s environment and its spatial orientation.&quot; [wikipedia:Spatial_memory]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T02:14:26Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000557 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000557">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000556"/>
+        <nbo:IAO_0000115>&quot;A type of memory that allows one to temporarily store and manage information about one&apos;s environment and its spatial orientation.&quot; [wikipedia:Spatial_memory]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T02:17:28Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term spatial memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000558 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000558">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T02:19:43Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term spatial memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000559 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000559">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000152"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000450"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the activity in which a mother cleans or maintains the body or the appearance of her offsprings.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T07:58:09Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal grooming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000560 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000560">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
+        <nbo:IAO_0000115>&quot;Behavior relating to the plucking of fur/hair or whiskers/vibrissae.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:03:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">barbering behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000561 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000561">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000560"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the barbering of other individuals of a cohort.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:04:13Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000083</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>whisker trimming</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>MP:0001446</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hetero-barbering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000562 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000562">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000560"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the barbering of oneself.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:05:32Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">self-barbering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000563 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000563">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000595"/>
+        <nbo:IAO_0000115>&quot;A pathological behavior characterized by muscular rigidity and fixation of posture regardless of external stimuli, as well as decreased sensitivity to pain.&quot; [wikipedia:Catalepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:14:28Z</dc:date>
+        <oboInOwl:xref>MP:0002822</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catalepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000564 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000564">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0035176"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior that occurs predominantly or only, in individuals that are part of a group.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:24:37Z</dc:date>
+        <oboInOwl:hasExactSynonym>pathological social behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000565 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000565">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000564"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:24:50Z</dc:date>
+        <oboInOwl:xref>MP:0001361</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social withdrawal</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000566 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000566">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000565"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:25:50Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social withdrawal in childhood</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000567 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000567">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
+        <nbo:IAO_0000115>&quot;A pathological behavior associated with repetitive or ritualistic movement, posture, or utterance.&quot; [wikipedia:Stereotypy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:28:29Z</dc:date>
+        <oboInOwl:hasExactSynonym>stereotypic behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>stereotypy</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0000733</oboInOwl:xref>
+        <oboInOwl:xref>MP:0001408</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stereotypic behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000568 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000568">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000338"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the movement of the body&apos;s muscles, tendons, and joints.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:31:34Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinesthetic behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000569 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000569">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
+        <nbo:IAO_0000115>&quot;Exhibiting abnormal exhaustion due to mental or physical exertion.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:32:15Z</dc:date>
+        <oboInOwl:xref>MP:0002899</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fatigue</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000570 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000570">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Movement of the head in the vertical plane. [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:39:38Z</dc:date>
+        <oboInOwl:hasExactSynonym>head nodding</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym xml:lang="en">nod head</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head bobbing</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000571 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000571">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
+        <nbo:IAO_0000115>&quot;Movement of the head in multiple directions.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T08:43:33Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multidirectional head movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000572 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000572">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:IAO_0000115>&quot;A degenerative state of the brain resulting in impairment of memory, judgment, attention span, problem solving skills, the inability to perform previously learned skills that cannot be attributed to deficits of motor or sensory function, and a global loss of cognitive abilities.&quot; [MeSH:National Library of Medicine_Medical Subject Headings]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T09:01:45Z</dc:date>
+        <oboInOwl:xref>MP:0002571</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">senility</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000573 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000573">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T09:04:45Z</dc:date>
+        <oboInOwl:xref>MP:0002573</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral despair</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000574 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000574">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
+        <nbo:IAO_0000115>&quot;A reflex allows the eye to follow objects in motion when the head remains stationary.&quot; [wikipedia:Optokinetic_reflex]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T09:20:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optokinetic reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000575 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000575">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex that elucidates goose bumps (bumps on a person&apos;s skin at the base of body hairs) which may involuntarily develop when a person is cold or experiences strong emotions such as fear, awe, admiration or sexual arousal&quot; [wikipedia:Goose_bumps]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:15:17Z</dc:date>
+        <oboInOwl:hasExactSynonym>horripilation</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>piloerection</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pilomotor reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000576 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000576">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex that elucidates a characteristic ear twitch in response to an auditory stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:19:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>Preyer&apos;s reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pinna reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000577 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000577">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A reflex that maintains body position and equilibrium either during rest or during movement.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:24:14Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">postural reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000578 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000578">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
+        <nbo:IAO_0000115>&quot;A reflex process in which an animal immediately tries to turn over after being placed in a supine position.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:28:56Z</dc:date>
+        <oboInOwl:hasExactSynonym>righting response</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">righting reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000579 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000579">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000005"/>
+        <nbo:IAO_0000115>&quot;A pathological behavior characterised by pronounced startle responses to tactile or acoustic stimuli and hypertonia.&quot; [wikipedia:Hyperekplexia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:37:34Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hyperekplexia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000580 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000580">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
+        <nbo:IAO_0000115>&quot;A reflex that elucidates an automatic positioning of the limbs in response to a movement of the head on trunk (neck).&quot; [web:http\://www.dizziness-and-balance.com/anatomy/vspine.htm]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:42:28Z</dc:date>
+        <oboInOwl:hasExactSynonym>TNR</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>cervicospinal reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tonic neck reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000581 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000581">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
+        <nbo:IAO_0000115>&quot;A reflex which results from activation of afferents from the vestibular organs and uses neck movements to stabilize the head position in space.&quot; [JAX:]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:44:18Z</dc:date>
+        <oboInOwl:hasExactSynonym>VCR</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibulocollic reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000582 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000582">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
+        <nbo:IAO_0000115>&quot;A reflex that originates with vestibular stimulation and control body posture.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:47:03Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibulospinal reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000583 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000583">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;Change position in response to stimulation of the whiskers.&quot; [JAX:&lt;new dbxref&gt;]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:52:19Z</dc:date>
+        <oboInOwl:hasExactSynonym>vibrissa reflex</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vibrissae reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000584 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000584">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
+        <nbo:IAO_0000115>&quot;A mouse reflex that elicidated the clasping of front and/or hind feet almost immediately upon being lifted by tail.&quot; [EUROPHENOME:]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T10:55:22Z</dc:date>
+        <oboInOwl:hasExactSynonym>hindlimb extension reflex</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>limb clasping</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>limb grasping</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clutching reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000585 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000585">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000587"/>
+        <nbo:IAO_0000115>&quot;A form of tetanic spasm in which the head and feet are drawn forward and the spine arches backward.&quot; [JAX:]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:05:57Z</dc:date>
+        <oboInOwl:xref>MP:0009354</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emprosthotonos</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000586 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000586">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000587"/>
+        <nbo:IAO_0000115>&quot;A form of tetanic spasm in which the head, neck and spine are bent backward and the body is bowed forward.&quot; [JAX:]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:08:01Z</dc:date>
+        <oboInOwl:xref>HP:0002179</oboInOwl:xref>
+        <oboInOwl:xref>MP:0002880</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">opisthotonus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000587 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000587">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000588"/>
+        <nbo:IAO_0000115>&quot;A sudden, involuntary contraction of a muscle or group of muscles associated with strychnine poisoning and tetanus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:09:10Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tetanic spasm</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000588 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000588">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
+        <nbo:IAO_0000115>&quot;A sudden, involuntary contraction of a muscle or group of muscles.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:10:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spasm</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000589 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000589">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
+        <nbo:IAO_0000115>&quot;An involuntary rhythmical, oscillatory movement of a body part.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:13:39Z</dc:date>
+        <oboInOwl:hasExactSynonym>quivering</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>shivering</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>trembling</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0001337</oboInOwl:xref>
+        <oboInOwl:xref>MP:0000745</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tremor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000590 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000590">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000591"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000339"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000770"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Inability to coordinate voluntary muscular movements.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:25:59Z</dc:date>
+        <oboInOwl:xref>HP:0001251</oboInOwl:xref>
+        <oboInOwl:xref>MP:0001393</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ataxia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000591 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000591">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000339"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000229"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the coordination of combinations of body movements created with the kinematic (such as spatial direction) and kinetic (force) parameters that result in intended actions.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:32:30Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motor coordination phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000592 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000592">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000591"/>
+        <nbo:IAO_0000115>&quot;Lack of coordination of movement typified by the undershoot or overshoot of intended position with the hand, arm, leg, or eye.&quot; [wikipedia:Dysmetria]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:33:13Z</dc:date>
+        <oboInOwl:xref>MP:0003314</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dysmetria</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000593 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000593">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000592"/>
+        <nbo:IAO_0000115>&quot;Overshooting the intended position.&quot; [wikipedia:Dysmetria]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:34:23Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypermetria</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000594 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000594">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000592"/>
+        <nbo:IAO_0000115>&quot;Undershooting the intended position.&quot; [wikipedia:Dysmetria]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:34:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypometria</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000595 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000595">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000229"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related with the Intentionally or habitually assumed arrangement of the body and its limbs.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:37:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">posture phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000596 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000596">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000595"/>
+        <nbo:IAO_0000115>&quot;Posture distinguished by a faltering gait while walking and/or a swaying motion of the trunk or head while resting.&quot; [JAX:&lt;new dbxref&gt;]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T11:37:27Z</dc:date>
+        <oboInOwl:xref>MP:0009514</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">titubation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000597 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000597">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
+        <nbo:IAO_0000115>&quot;Loss of power of voluntary movement in the muscles of the hindlimb through injury or disease of it or its nerve supply.&quot; [JAX:]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:20:30Z</dc:date>
+        <oboInOwl:xref>MP:0000755</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hindlimb paralysis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000598 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000598">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
+        <nbo:IAO_0000115>&quot;A locomotory disorder in which sustained muscle contractions cause twisting and repetitive movements or abnormal postures.&quot; [wikipedia:Dystonia]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:24:20Z</dc:date>
+        <oboInOwl:xref>HP:0001332</oboInOwl:xref>
+        <oboInOwl:xref>MP:0005323</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dystonia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000599 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000599">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000556"/>
+        <nbo:IAO_0000115>&quot;A type of memory that allows one to store and manage information about one&apos;s environment and its spatial orientation lasting hours to months.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T01:43:30Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long-term spatial memory</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000600 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000600">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000129"/>
+        <nbo:IAO_0000115>&quot;Agitation characterised by a series of unintentional and purposeless motions that stem from mental tension and anxiety of an individual.&quot; [wikipedia:Psychomotor_agitation]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:03:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">psychomotor agitation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000601 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000601">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000003"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the complex psychophysiological experience of an individual&apos;s state of mind as interacting with biochemical (internal) and environmental (external) influences.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:07:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emotional behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000602 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000602">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
+        <nbo:IAO_0000115>&quot;Exhibiting indifference, or suppression of emotions such as concern, excitement, motivation and passion.&quot; [wikipedia:Indifference_(emotion)]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:07:51Z</dc:date>
+        <oboInOwl:hasExactSynonym>impassivity</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>perfunctoriness</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0000741</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">apathy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000603 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000603">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:IAO_0000115>&quot;A belief that is either mistaken or not substantiated that is held with vehemence.&quot; [wikipedia:Delusion]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:20:48Z</dc:date>
+        <oboInOwl:xref>HP:0000746</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delusion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000604 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000604">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:IAO_0000115>&quot;A social behavior characterised by conscious or unconscious constraint of a behavior that might be considered objectionable in a social setting.&quot; [wikipedia:Social_inhibition]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:33:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social inhibition</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000605 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000605">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:IAO_0000115>&quot;A social behavior characterised by conscious or unconscious constraint or curtailment of behavior relating to specific sexual matters or practices.&quot; [wikipedia:Sexual_inhibition]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:34:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual inhibition</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000606 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000606">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0002361"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000304"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:IAO_0000115>&quot;Loss of information already encoded and stored in an individual&apos;s long term memory.&quot; [wikipedia:Forgetting]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:42:46Z</dc:date>
+        <oboInOwl:hasExactSynonym>pathological forgetting</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>retention loss</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0000747</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">forgetfulness</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000607 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000607">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Behaviour related to cognitive processes.&quot; [NBO:JH]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:51:13Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cognitive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000608 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000608">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:IAO_0000115>&quot;Perception in the absence of a stimulus.&quot; [wikipedia:Hallucination]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:52:31Z</dc:date>
+        <oboInOwl:xref>HP:0000738</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hallucination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000609 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000609">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000608"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002104"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000608"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002104"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A form of hallucination that involves perceiving images without visual stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:54:02Z</dc:date>
+        <oboInOwl:hasExactSynonym>paracusia</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0008765</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual hallucination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000610 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000610">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000608"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002105"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000608"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002105"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A form of hallucination that involves perceiving sounds without auditory stimulus.&quot; [wikipedia:Auditory_hallucination]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:56:24Z</dc:date>
+        <oboInOwl:xref>HP:0002367</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">auditory hallucination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000611 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000611">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000608"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005725"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000608"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005725"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A form of hallucination that involves perceiving odors without odor stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T03:58:15Z</dc:date>
+        <oboInOwl:hasExactSynonym>phantosmia</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory hallucination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000612 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000612">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
+        <nbo:IAO_0000115>&quot;A social behavior related to the activity of conveying information.&quot; [wikipedia:Communication]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:39:42Z</dc:date>
+        <oboInOwl:hasExactSynonym>communicating</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">signal exchange</oboInOwl:hasNarrowSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">communication behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000613 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000613">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
+        <nbo:IAO_0000115>&quot;Communication behavior related to the process of conveying meaning in the form of non-word messages through for example gesture, body language or posture; facial expression and eye contact etc.&quot; [wikipedia:.wikipedia.org/wiki/Nonverbal_communication]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:40:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>non-verbal communication behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>nonverbal communication behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nonverbal communication behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000614 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000614">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
+        <nbo:IAO_0000115>&quot;Communication behavior related to the conveyance of ideas and information through creation of visual representations.&quot; [wikipedia:Visual_communication]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:42:57Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual communication behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000615 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000615">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
+        <nbo:IAO_0000115>&quot;Communication behavior related to the process of conveying meaning in the form of word messages.&quot; [wikipedia:Oral_communication#Oral_communication]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:44:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oral communication behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000616 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000616">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000613"/>
+        <nbo:IAO_0000115>&quot;A nonverbal communication behavior that is characterised by the meeting the eyes between two individuals.&quot; [wikipedia:Eye_contact]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:46:09Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye contact</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000617 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000617">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:51:05Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">laughing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000618 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000618">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:IAO_0000115>&quot;The behavior in which an organism sheds tears, often accompanied by non-verbal vocalizations and in response to external or internal stimuli.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:52:56Z</dc:date>
+        <oboInOwl:hasExactSynonym>crying behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0060273</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crying behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000619 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000619">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
+        <nbo:IAO_0000115>&quot;Behavior stemming from understanding of a specific cause and effect in a specific context.&quot; [wikipedia:Insight]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T04:57:19Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from insight</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000620 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000620">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+        <nbo:IAO_0000115>&quot;An emotional behavior that arises from the perceived resistance to the fulfillment of individual will.&quot; [wikipedia:Frustration]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T05:00:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frustration behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000621 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000621">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000564"/>
+        <nbo:IAO_0000115>&quot;A communication disorder in which a person, most often a child, who is normally capable of speech is unable to speak in given situations, or to specific people.&quot; [wikipedia:Selective_mutism]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T05:06:03Z</dc:date>
+        <oboInOwl:xref>HP:0002300</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">selective mutism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000622 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000622">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000567"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any highly repetitive behavior, where the repetition is unusual, difficult to disrupt, and neither the behavior nor repetition serve an obvious function [NBO:AC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T05:18:30Z</dc:date>
+        <oboInOwl:xref>HP:0008758</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stereotypic motor behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000623 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000623">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000567"/>
+        <nbo:IAO_0000115>&quot;Stereotypic behavior characterised by a tendency to repeat vocalizations.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-14T05:20:29Z</dc:date>
+        <oboInOwl:xref>HP:0010529</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">echolalia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000624 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000624">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
+        <nbo:IAO_0000115>&quot;Play behavior associated with the manipulation of objects.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T10:51:54Z</dc:date>
+        <rdfs:comment>Object play is important in developing skills important in adulthood, especially hunting.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">object play</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000626 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000626">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
+        <nbo:IAO_0000115>&quot;Behavior associated with interactions which resemble sexual behavior but do not lead to copulation.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Sex%20Play.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T10:52:50Z</dc:date>
+        <oboInOwl:hasExactSynonym>love play</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual play</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000627 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000627">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
+        <nbo:IAO_0000115>&quot;Play behavior associated to fighting simulation, although fighting is much slower and gentler with no intention of actual hurt.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Play%20Fighting.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T10:53:55Z</dc:date>
+        <rdfs:comment>Play fighting helps learning to evaluate oneself and an opponent. This skill is crucial for serious adult situations. Being able to size up an opponent quickly is very important in knowing when to give up or fight for a resource (food, mate, territory, etc. ). Play fighting is one of the most important categories of play because it prepares animals for actual fighting.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">play fight</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000628 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000628">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
+        <nbo:IAO_0000115>&quot;Play behavior that is associated with the pursuit of an individual.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T10:54:09Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">play chasing</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000629 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000629">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
+        <nbo:IAO_0000115>&quot;Play behavior associated with the exhibition of parenting behavior by non-parents.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T11:03:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nursing play</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000630 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000630">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
+        <nbo:IAO_0000115>&quot;Play behavior related to the copying the actions of another.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Imitative%20Play.html]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T11:07:20Z</dc:date>
+        <rdfs:comment>Imitative play is an excellent means of learning how to perform a task that an adult has perfected. Therefore, imitative play is one of the best ways for animals to learn from the adults in the group.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">imitative play</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000631 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000631">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000087"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000741"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Harassment of and-or attack of a presumed predator or intruder by multiple individuals at once [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T01:44:21Z</dc:date>
+        <oboInOwl:hasExactSynonym xml:lang="en">mobbing</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mobbing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000632 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000632">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000036"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000631"/>
+        <nbo:IAO_0000115>&quot;Behavior associated with signals made by the mobbing species while harassing a predator.&quot; [wikipedia:Mobbing_(animal_behavior)]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T01:46:33Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mobbing calling</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000633 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000633">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
+        <nbo:IAO_0000115>&quot;Aggressive behavior related to the defence of a fixed area against intruders, typically conspecifics.&quot; [GOC:hjd]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T02:02:11Z</dc:date>
+        <oboInOwl:hasExactSynonym>territorial aggression</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>territorial aggressive behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0002124</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">territorial aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000634 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000634">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0002118"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000128"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0002118"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000741"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#by_means"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000128"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T02:05:35Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">irritable aggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000635 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000635">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the activity seen in animals exposed to adverse stimuli, in which the tendency to act defensively is stronger than the tendency to attack.&quot; [web:http\://www.britannica.com/EBchecked/topic/45916/avoidance-behavior]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T03:36:00Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">avoidance behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000636 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000636">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000635"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the activity seen in animals exposed to potential danger in which they exhibit the tendency to act defensively.&quot; [NBO:SD]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-19T03:49:55Z</dc:date>
+        <oboInOwl:hasExactSynonym>defense</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>defensive behaviour</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protective behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000637 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000637">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
+        <nbo:IAO_0000115>&quot;The actions or reactions of a male, for the purpose of attracting a sexual partner.&quot; [GOC:bf]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-21T08:40:33Z</dc:date>
+        <oboInOwl:hasExactSynonym>male courtship behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0008049</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male courtship behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000638 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000638">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
+        <nbo:IAO_0000115>&quot;The actions or reactions of a female, for the purpose of attracting a sexual partner.&quot; [GOC:bf]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-21T08:42:23Z</dc:date>
+        <oboInOwl:hasExactSynonym>female courtship behaviour</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>GO:0008050</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female courtship behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000639 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000639">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000234"/>
+        <nbo:IAO_0000115>&quot;Any process which modulates the physical craving for water over long term water deprivation.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-21T09:06:28Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term thirst regulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000640 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000640">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000234"/>
+        <nbo:IAO_0000115>&quot;Any process which modulates the physical craving for water over short term water deprivation.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-04-21T09:06:40Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term thirst regulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000641 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000641">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-06T03:56:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">discrimination learning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000642 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000642">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
+        <nbo:IAO_0000115>&quot;Two or more unprovoked recurrent seizures.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T11:42:33Z</dc:date>
+        <oboInOwl:hasExactSynonym>unprovoked seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0001275</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000643 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000643">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000388"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000568"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to movements that occur independent of planning.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T11:56:52Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">involuntary movement behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000644 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000644">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000403"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000568"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to movements executed with intent.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T11:57:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">voluntary movement behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000645 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000645">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
+        <nbo:IAO_0000115>&quot;A rapid and repeated body muscle contract that results in an uncontrolled shaking of the body.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T11:59:40Z</dc:date>
+        <oboInOwl:hasExactSynonym>fit</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">convulsion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000646 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000646">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
+        <nbo:IAO_0000115>&quot;A seizure which affect only a part of the brain at onset.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Focal_seizures]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T12:49:09Z</dc:date>
+        <oboInOwl:hasExactSynonym>focal seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>localized seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0007359</oboInOwl:xref>
+        <rdfs:comment>Partial seizures begin with an electrical discharge in one limited area of the brain.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">partial seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000647 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000647">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
+        <nbo:IAO_0000115>&quot;A partial seizure which affect only a small region of the brain, often the temporal lobes and/or hippocampi whilst consciousness is unaffected.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Simple_partial_seizure]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T12:51:40Z</dc:date>
+        <oboInOwl:xref>HP:0002349</oboInOwl:xref>
+        <rdfs:comment>Depending on the area of cerebral cortex involved, symptoms may be motor, cognitive, sensory, autonomic, or affective. Consciousness is not impaired.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000648 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000648">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
+        <nbo:IAO_0000115>&quot;A seizure that is associated with bilateral cerebral hemisphere involvement and causes impairment of awareness or responsiveness, i.e. loss of consciousness.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Complex_partial_seizures]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T12:59:01Z</dc:date>
+        <oboInOwl:hasExactSynonym>psychomotor seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>temporal lobe seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0002384</oboInOwl:xref>
+        <oboInOwl:xref>MP:0002195</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex partial seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000649 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000649">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000065"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T01:51:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">being conscious</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000650 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000650">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of focal epilepsy characterized by recurrent seizures.&quot; [NBO:http\://en.wikipedia.org/wiki/Temporal_lobe_epilepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T02:42:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>psychomotor epilepsy</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">temporal lobe epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000651 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000651">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
+        <nbo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T02:50:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>focal clonic seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>motor seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0002266</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure with motor signs</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000652 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000652">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
+        <nbo:IAO_0000115>&quot;A simple partial seizure affecting any of the five senses -- vision, touch, smell, taste, and hearing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T02:51:16Z</dc:date>
+        <oboInOwl:hasExactSynonym>Jacksonian sensory seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>sensory seizure</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Some simple partial seizures consist of a sensory experience. The person may see lights, hear a buzzing sound, or feel tingling or numbness in a part of the body.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure with sensory symptoms</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000653 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000653">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
+        <nbo:IAO_0000115>&quot;A simple partial seizure affecting the part of the nervous system that automatically controls bodily functions.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T02:51:31Z</dc:date>
+        <oboInOwl:hasExactSynonym>abdominal epilepsy</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>autonomic seizure</oboInOwl:hasExactSynonym>
+        <rdfs:comment>These seizures are accompanied by autonomic symptoms or signs, such as abdominal discomfort or nausea which may rise into the throat (epigastric rising), stomach pain, the rumbling sounds of gas moving in the intestines (borborygmi), belching, flatulence and vomiting. Other symptoms may include pallor, flushing, sweating, hair standing on end (piloerection), dilation of the pupils, alterations in heart rate and respiration, and urination. A few people may experience sexual arousal, penile erection, and orgasm.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure with autonomic symptoms or signs</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000654 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000654">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
+        <nbo:IAO_0000115>&quot;A simple partial seizure affecting the emotional behavior.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T02:51:48Z</dc:date>
+        <oboInOwl:hasExactSynonym>psychic seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>simple partial seizures of temporal lobe origin</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>temporal lobe auras</oboInOwl:hasExactSynonym>
+        <rdfs:comment>Simple partial seizures which arise in or near the temporal lobes often take the form of an odd experience. One may see or hear things that are not there. One feels emotions, often fear, but sometimes sadness, anger, or joy. There may be a bad smell or a bad taste, a funny feeling in the pit of the stomach or a choking sensation.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure with psychic symptoms</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000655 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000655">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000308"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related any of the five senses -- vision, touch, smell, taste, and hearing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:06:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensation behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000656 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000656">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000327"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
+        <nbo:IAO_0000115>&quot;A phenotype manifested by a behavior related to the sensations arising from the skin and from the muscles, tendons, and joints.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:20:39Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somatic sensation related behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000657 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000657">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000330"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000656"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:21:20Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cutaneous sensation behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000658 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000658">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0031223"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or reactions of an organism in response to a sound.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:22:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">auditory behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000659 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000659">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007632"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
+        <nbo:IAO_0000115>&quot;A phenotype manifested by a behavior related to the actions or reactions of an organism in response to a visual stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:22:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000660 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000660">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007635"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the sensation of chemicals.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:26:33Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemosensory behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000661 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000661">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000323"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000660"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the sensation of odors.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:28:54Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000662 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000662">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
+        <nbo:IAO_0000115>&quot;A seizure which affect the whole of the brain at onset.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:46:46Z</dc:date>
+        <oboInOwl:hasExactSynonym>primarily generalized seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0002197</oboInOwl:xref>
+        <rdfs:comment>Primary generalized seizures begin with a widespread electrical discharge that involves both sides of the brain at once.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">generalized seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000663 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000663">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:49:54Z</dc:date>
+        <oboInOwl:xref>HP:0007334</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">partial seizure evolving to secondarily generalized seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000664 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000664">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000663"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:50:07Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure evolving to generalized seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000665 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000665">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000663"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:50:26Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex partial seizure evolving to generalized seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000666 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000666">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000663"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:50:49Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure evolving to complex partial seizure evolving to generalized seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000667 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000667">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000648"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:51:50Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial onset, followed by impairment of consciousness</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000668 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000668">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000648"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:52:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">with impairment of consciousness at onset</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000669 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000669">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
+        <nbo:IAO_0000115>&quot;An absence seizure is a brief (usually less that 20 seconds), generalized epileptic seizure of sudden onset and termination.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Absence_seizure]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:54:48Z</dc:date>
+        <oboInOwl:hasExactSynonym>petit mal seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0002121</oboInOwl:xref>
+        <oboInOwl:xref>MP:0003216</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">absence seizures</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000670 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000670">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
+        <nbo:IAO_0000115>&quot;A type of generalized seizure that consist of a brief lapse in muscle tone that are caused by temporary alterations in brain function.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Atonic_seizure]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T03:57:35Z</dc:date>
+        <oboInOwl:hasExactSynonym>akinetic seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drop attack</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>drop seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0010819</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000671 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000671">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
+        <nbo:IAO_0000115>&quot;A type of seizure that is characterised by a very brief symmetric alternating contraction and relaxation of a muscle or a group of muscles.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T04:52:23Z</dc:date>
+        <oboInOwl:hasExactSynonym>myoclonus</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0001336</oboInOwl:xref>
+        <oboInOwl:xref>HP:0002123</oboInOwl:xref>
+        <oboInOwl:xref>MP:0000243</oboInOwl:xref>
+        <rdfs:comment>Symmetric jerking of the extremities.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myoclonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000672 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000672">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
+        <nbo:IAO_0000115>&quot;A type of seizure that is characterised by rhythmic symmetric alternating contraction and relaxation of a muscle or a group of muscles.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T04:54:59Z</dc:date>
+        <oboInOwl:xref>MP:0003996</oboInOwl:xref>
+        <rdfs:comment>Rapid, repetitive motor activity.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">clonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000673 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000673">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000688"/>
+        <nbo:IAO_0000115>&quot;A type of epilepsy characterised by myoclonic seizures usually involving the neck, shoulders, and upper arms.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T04:55:32Z</dc:date>
+        <oboInOwl:hasExactSynonym>Janz syndrome</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">juvenile myoclonic epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000674 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000674">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of epilepsy characterised by multiple different types of seizures, particularly including tonic (stiffening) and atonic (drop) types of seizures.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T04:56:28Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lennox-Gastaut syndrome</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000675 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000675">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure generated by sudden sensor stimulation caused by the environment.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T11:07:41Z</dc:date>
+        <oboInOwl:hasExactSynonym>environmental epilepsy</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>reflex epilepsy</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>MP:0009358</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reflex seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000676 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000676">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
+        <nbo:IAO_0000115>&quot;A type of generalized seizure characterised by a combination of tonic stiffening (extensions) followed by clonic flexion motions.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:03:11Z</dc:date>
+        <oboInOwl:hasExactSynonym>gran mal seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>grand mal seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0002069</oboInOwl:xref>
+        <oboInOwl:xref>MP:0003997</oboInOwl:xref>
+        <rdfs:comment>The seizures are divided into two phases, the tonic phase and the clonic phase, hence the name of the seizure, though a tonic clonic seizure will often be preceded by an aura.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tonic clonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000677 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000677">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
+        <nbo:IAO_0000115>&quot;A type of seizure characterised by muscle rigidity.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:09:15Z</dc:date>
+        <oboInOwl:xref>HP:0010818</oboInOwl:xref>
+        <oboInOwl:xref>MP:0002826</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000678 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000678">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure associated with a significant rise in body temperature.&quot; [wikpedia:http\://en.wikipedia.org/wiki/Febrile_seizure]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:13:26Z</dc:date>
+        <oboInOwl:hasExactSynonym>febrile convulsion</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>fever fit</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0002373</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">febrile seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000679 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000679">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000678"/>
+        <nbo:IAO_0000115>&quot;A febrile seizure that lasts less than 15 minutes , does not recur in 24 hours, and involves the entire body.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Febrile_seizure]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:16:07Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple febrile seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000680 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000680">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000678"/>
+        <nbo:IAO_0000115>&quot;A febrile seizure characterized by longer duration, recurrence, or focus on only part of the body.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Febrile_seizure]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:19:54Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex febrile seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000681 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000681">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;Benign rolandic epilepsy is characterized by either simple partial seizures involving the mouth and face or generalized tonic-clonic seizures.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Rolandic_epilepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:24:49Z</dc:date>
+        <oboInOwl:hasExactSynonym>benign (childhood) epilepsy with centrotemporal (EEG) spikes</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">benign rolandic epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000682 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000682">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000650"/>
+        <nbo:IAO_0000115>&quot;A temporal lobe epilepsy arises in the hippocampus, parahippocampal gyrus and amygdala which are located in the inner aspect of the temporal lobe.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Temporal_lobe_epilepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:30:25Z</dc:date>
+        <oboInOwl:hasExactSynonym>MTLE</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medial temporal lobe epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000683 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000683">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000650"/>
+        <nbo:IAO_0000115>&quot;A temporal lobe epilepsy arises in the neocortex on the outer surface of the temporal lobe of the brain.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Temporal_lobe_epilepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:31:27Z</dc:date>
+        <oboInOwl:hasExactSynonym>LTLE</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lateral temporal lobe epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000684 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000684">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:32:59Z</dc:date>
+        <oboInOwl:hasExactSynonym>pyknolepsy</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">childhood absence epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000685 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000685">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:39:40Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">continuous seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000686 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000686">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
+        <nbo:IAO_0000115>&quot;Paroxysmal events that mimic an epileptic seizure but do not involve abnormal, rhythmic discharges of cortical neurons.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Non-epileptic_seizure]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:47:13Z</dc:date>
+        <oboInOwl:hasExactSynonym>non-epileptic seizure</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">provoked seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000687 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000687">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure of psychological origin that superficially resembles an epileptic seizure, but without the characteristic electrical discharges associated with epilepsy.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Psychogenic_non-epileptic_seizures]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:50:08Z</dc:date>
+        <oboInOwl:hasExactSynonym>PNES</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>non-epileptic attack disorder</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">psychogenic non-epileptic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000688 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000688">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of epilepsy that is characterised by myoclonic seizures.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:53:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myoclonic epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000689 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000689">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000688"/>
+        <nbo:IAO_0000115>&quot;A myoclonic epilepsy characterised by a combination of myoclonic and tonic-clonic seizures.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Progressive_myoclonic_epilepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:55:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">progressive myoclonic epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000690 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000690">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;Continuous unremitting seizure lasting longer than 30 minutes or recurrent seizures without regaining consciousness between seizures for greater than 30 minutes.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Status_epilepticus]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T05:59:47Z</dc:date>
+        <oboInOwl:xref>HP:0002133</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">status epilepticus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000691 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000691">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T06:42:06Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-convulsive status epilepticus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000692 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000692">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T06:42:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">generalised convulsive status epilepticus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000693 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000693">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000691"/>
+        <nbo:IAO_0000115>&quot;A convulsive status epilepticus characterized by seizures involving long-lasting stupor, staring and unresponsiveness.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Complex_partial_status_epilepticus]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T07:20:21Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex partial status epilepticus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000694 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000694">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000691"/>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-27T07:21:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">absence status epilepticus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000695 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000695">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
+        <nbo:IAO_0000115>&quot;Subtle  status epilepticus consists of electrical seizure activity in the brain that endures when the associated motor responses are fragmentary or even absent.&quot; [web:http\://emedicine.medscape.com/article/1164462-overview]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T10:08:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">subtle status epilepticus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000696 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000696">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
+        <nbo:IAO_0000115>&quot;Simple partial SE consists of seizures that are localized to a discrete area of cerebral cortex and produce no alteration in consciousness.&quot; [web:http\://emedicine.medscape.com/article/1164462-overview]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T10:10:13Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial status epilepticus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000697 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000697">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of epilepsy characterized by brief, recurring seizures that arise in the frontal lobes of the brain, often while the patient is sleeping.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Frontal_lobe_epilepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T10:14:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frontal lobe epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000698 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000698">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of epilepsy characterised by seizure, usually tonic clonic, that occur only during sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T10:17:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nocturnal epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000699 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000699">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000675"/>
+        <nbo:IAO_0000115>&quot;A type of reflex seizure caused by visual stimuli that form patterns in time or space, such as flashing lights, bold, regular patterns, or regular moving patterns.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Photosensitive_epilepsy]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T11:11:25Z</dc:date>
+        <oboInOwl:hasExactSynonym>photosensitive epilepsy</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">photosensitive seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000700 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000700">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000675"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by exposure to an auditory stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T11:12:23Z</dc:date>
+        <oboInOwl:hasAlternativeId>NBO:0000725</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasExactSynonym>auditory stimulation induced seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>MP:0001496</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">audiogenic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000701 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000701">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000669"/>
+        <nbo:IAO_0000115>&quot;An absence seizure induced by hyperventilation.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T11:59:14Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">typical absence seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000702 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000702">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000669"/>
+        <nbo:IAO_0000115>&quot;An absence seizure not induced by hyperventilation.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T11:59:31Z</dc:date>
+        <oboInOwl:xref>HP:0007270</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atypical absence seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000703 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000703">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
+        <nbo:IAO_0000115>&quot;A generalized seizure that was initiated as a partial seizure.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:08:24Z</dc:date>
+        <oboInOwl:xref>HP:0002434</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secondary generalized seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000704 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000704">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000703"/>
+        <nbo:IAO_0000115>&quot;A generalized seizure that was initiated as a partial seizure but very rapidly spread to both hemispheres.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:11:05Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rapid secondary generalization</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000705 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000705">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
+        <nbo:IAO_0000115>&quot;Purposeless repetitive motor activities that often occur during a seizure.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:14:35Z</dc:date>
+        <rdfs:comment>Automatisms may occur during complex partial or absence seizures.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">automatism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000706 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000706">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000705"/>
+        <nbo:IAO_0000115>&quot;An automatism characterised by involuntary oral activity such as lip smacking and swallowing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:15:48Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oral automatism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000707 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000707">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000705"/>
+        <nbo:IAO_0000115>&quot;An automatism characterised by involuntary movement of the limbs or body such as  fumbling, picking and rubbing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:17:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gestural automatism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000708 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000708">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000705"/>
+        <nbo:IAO_0000115>&quot;An automatism characterised by stereotyped series of motor actions usually involving the limbs bilaterally such as swimming \nmovements, kicking movements and bicycling movements.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:20:03Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex motor automatism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000709 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000709">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of a drug.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:32:11Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drug induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000710 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000710">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000709"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by accidental or intentional ingestion or application of a drug in quantities greater than recommended.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:34:37Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drug overdose induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000711 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000711">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000709"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by termination of drug administration.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:35:22Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drug withdrawal induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000712 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000712">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood glucose levels.&quot; [GVG:NBO]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:35:56Z</dc:date>
+        <oboInOwl:xref>HP:0002173</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypoglycemia induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000713 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000713">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of cocaine.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:36:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cocaine overdose induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000714 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000714">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of isoniazide.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:36:46Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">isoniazide overdose induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000715 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000715">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of amphetamine.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T12:37:01Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amphetamine overdose induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000716 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000716">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of antidepressant.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:14:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">antidepressant overdose induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000717 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000717">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of theophylline.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:15:33Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">theophylline overdose induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000718 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000718">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of penicillin.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:16:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">penicillin overdose induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000719 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000719">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by termination of alcohol administration.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:19:06Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol withdrawal induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000720 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000720">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by termination of benzodiazepine administration.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:22:57Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">benzodiazepine withdrawal induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000721 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000721">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by termination of barbiturates administration.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:24:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">barbiturates withdrawal induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000722 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000722">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by termination of heroin administration.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:26:05Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heroin withdrawal induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000723 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000723">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood magnesium levels.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:34:40Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypomagnesemia induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000724 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000724">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by exposure to an electrical stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T01:42:36Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electrical stimulation induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000726 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000726">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by the administration of a brain trauma.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T03:39:02Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trauma induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000727 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000727">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of seizure invoking stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T03:46:52Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kindling induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000728 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000728">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000727"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of electrical stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T03:50:30Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electrical kindling induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000729 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000729">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000727"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of chemical stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T03:51:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical kindling induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000730 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000730">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000727"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of auditory stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T03:52:15Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">auditory kindling induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000731 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000731">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000651"/>
+        <nbo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior of one side of the body.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T05:51:10Z</dc:date>
+        <oboInOwl:hasExactSynonym>unilateral clonic seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0006813</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hemiclonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000732 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000732">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000731"/>
+        <nbo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior of left side of the body.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T06:01:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left side clonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000733 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000733">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000731"/>
+        <nbo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior of right side of the body.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T06:03:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right side clonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000734 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000734">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000588"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of epileptic seizures occurring in infants and characterised by clusters of myoclonic spasms.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T06:47:31Z</dc:date>
+        <oboInOwl:hasExactSynonym>Generalized Flexion Epilepsy</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Infantile Epileptic Encephalopathy</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Infantile Myoclonic Encephalopathy</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Massive Myoclonia</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>Salaam spasms</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>West syndrome</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>jackknife convulsions</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0002391</oboInOwl:xref>
+        <oboInOwl:xref>HP:0011097</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">infantile spasm</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000735 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000735">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood calcium levels.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T08:04:53Z</dc:date>
+        <oboInOwl:xref>HP:0002199</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypocalcemia induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000736 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000736">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000703"/>
+        <nbo:IAO_0000115>&quot;A generalized tonic clonic seizure that was initiated as a partial seizure.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T08:28:12Z</dc:date>
+        <oboInOwl:xref>HP:0002602</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secondary generalized tonic clonic seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000737 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000737">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
+        <nbo:IAO_0000115>&quot;A type of seizure induced by exposure to a light stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T08:34:10Z</dc:date>
+        <oboInOwl:xref>HP:0001327</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">photostimulation induced seizure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000738 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000738">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of epilepsy that is characterised a sudden burst of energy, usually in the form of laughing.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T11:12:42Z</dc:date>
+        <oboInOwl:hasExactSynonym>gelastic seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0010821</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gelastic epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000739 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000739">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
+        <nbo:IAO_0000115>&quot;A type of epilepsy that is characterised a sudden paroxysmal crying.&quot; [NBO:&lt;new dbxref&gt;, NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2011-05-28T11:18:45Z</dc:date>
+        <oboInOwl:hasExactSynonym>dacrystic seizure</oboInOwl:hasExactSynonym>
+        <oboInOwl:xref>HP:0010820</oboInOwl:xref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dacrystic epilepsy</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000740 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000740">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000015"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-02-16T01:16:13Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior by intent</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000741 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000741">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000015"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-02-16T01:16:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior by means</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000742 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000742">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
+        <nbo:IAO_0000115>&quot;Agressive behavior towards oneself.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-02-16T01:16:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">autoaggressive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000743 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000743">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115>&quot;An aggressive behavior towards other members of the society.&quot; [NBO:RH]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-02-16T02:27:08Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social aggression behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000744 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000744">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-16T04:51:23Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perception behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000745 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000745">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
+        <nbo:IAO_0000115>&quot;A social behavior related to the activity of conveying information by means of a system of arbitrary signals, such as voice sounds, gestures, or written symbols.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-16T05:13:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">language communication behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000746 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000746">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000308"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000117"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000117"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-16T05:57:42Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial perception</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000747 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000747">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000007"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-17T09:51:17Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jaw movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000748 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000748">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000007"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of displacing part or all of the tongue from its current position [NBO:SMAC]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-17T09:52:25Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tongue movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000749 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000749">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000750"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-17T09:53:29Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blinking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000750 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000750">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-17T09:54:30Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eyelid movement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000751 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000751">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-16T05:23:06Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perception behavior by means</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000752 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000752">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000331"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050967"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000331"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050967"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-17T03:59:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electrical nociceptive behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000753 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000753">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000161"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000474"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to all sleep stages in the circadian sleep/wake cycle other than REM sleep.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T10:59:20Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-rapid eye movement sleep behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000754 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000754">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042747"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000474"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the stage in the circadian sleep cycle during which dreams occur and the body undergoes marked changes including rapid eye movement, loss of reflexes, and increased pulse rate and brain activity.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T11:08:01Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rapid eye movement sleep phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000755 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000755">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0019098"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or interactions of an organism that are associated with reproduction.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:08:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reproductive behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000756 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000756">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007617"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the interactions between organisms for the purpose of mating.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:10:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000757 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000757">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0045297"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the specific actions or reactions of an organism following mating.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:10:27Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">post-mating behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000758 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000758">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000034"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:10:54Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual activity phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000759 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000759">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007619"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000756"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic related to the behavioral interactions between organisms for the purpose of attracting sexual partners.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:13:54Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">courtship behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000760 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000760">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008050"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000759"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or reactions of a female, for the purpose of attracting a sexual partner.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:16:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female courtship behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000761 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000761">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0008049"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000759"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or reactions of a male, for the purpose of attracting a sexual partner.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:16:49Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male courtship behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000762 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000762">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007620"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000758"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the act of sexual union between male and female, involving the transfer of sperm.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:22:41Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">copulation phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000763 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000763">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000549"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000758"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the female activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:22:53Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female sexual activity phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000764 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000764">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000548"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000758"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behavior related to the male activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:23:03Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male sexual activity phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000765 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000765">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000006"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to the acquisition and processing of information and/or the storage and retrieval of this information over time.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:33:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">learning and/or memory behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000766 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000766">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000022"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000765"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour associated with any process in an organism in which a relatively long-lasting adaptive behavioral change occurs as the result of experience.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:34:12Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">learning behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000767 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000767">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000170"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000765"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to the ability of an organism&apos;s ability to store, retain, and recall information and experiences.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T02:34:26Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory behavior behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000768 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000768">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000035"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T03:46:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emission behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000769 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000769">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000038"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000768"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to the elimination by an organism of the waste products that arise as a result of metabolic activity. These products include water, carbon dioxide (CO2), and nitrogenous compounds.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T03:46:55Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of excretion phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000770 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000770">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000039"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000769"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to the expulsion of feces from the rectum.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T03:47:09Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of defecation phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000771 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000771">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000040"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000769"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to the regulation of body fluids process by which parasympathetic nerves stimulate the bladder wall muscle to contract and expel urine from the body.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-19T03:48:16Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of urination phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000772 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000772">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000036"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000768"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-20T05:24:59Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of production of sound phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000773 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000773">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000041"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000768"/>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-20T05:25:03Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of external secretion phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000774 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000774">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000042"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000773"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour related to the regulated release of the aqueous layer of the tear film from the lacrimal glands.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-20T05:28:58Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of lacrimation phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000775 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000775">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0060273"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000772"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour in which an organism sheds tears, often accompanied by non-verbal vocalizations and in response to external or internal stimuli.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-20T05:30:38Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crying behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000776 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000776">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000632"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000772"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour associated with signals made by the mobbing species while harassing a predator.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-20T05:32:31Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mobbing calling phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000777 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000777">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000037"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000772"/>
+        <nbo:IAO_0000115>&quot;Observable characteristic of behaviour in which an organism produces sounds by a mechanism involving its respiratory system.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-20T05:34:04Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vocalization behavior phenotype</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000778 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000778">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000208"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000208"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#is_about"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:created_by>gkoutos</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date>2012-03-23T10:05:56Z</dc:date>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emotional conditioning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000851 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000851">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0042756"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has-input"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001563"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000540"/>
+        <rdfs:label xml:lang="en">increased amount of liquid in a single drinking act</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000886 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000886">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                                <owl:someValuesFrom>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has-input"/>
+                                        <owl:someValuesFrom>
+                                            <owl:Class>
+                                                <owl:intersectionOf rdf:parseType="Collection">
+                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                                                    <owl:Restriction>
+                                                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001563"/>
+                                                    </owl:Restriction>
+                                                </owl:intersectionOf>
+                                            </owl:Class>
+                                        </owl:someValuesFrom>
+                                    </owl:Restriction>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000540"/>
+        <rdfs:label xml:lang="en">increased amount of liquid in drinking regulation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000929 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000929">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000044"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000133"/>
+        <oboInOwl:note>&apos;participates in&apos; some 
+(&apos;regulation of drinking behavior&apos; and (has_quality some 
+(frequency and (towards some &apos;liquid consumption&apos;))))</oboInOwl:note>
+        <rdfs:label xml:lang="en">frequency of drinking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000961 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000961">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000380"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000929"/>
+        <rdfs:label xml:lang="en">increased frequency of drinking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0000993 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000993">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000381"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000929"/>
+        <rdfs:label xml:lang="en">decreased frequency of drinking</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001536 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001536">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009314"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:IAO_0000115>&quot;Behavior as a result of an electromagnetic radiation stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">behavioral response to radiation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001571 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001571">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009416"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001536"/>
+        <nbo:IAO_0000115>&quot;Behavior as a result of a light stimulus, electromagnetic radiation of wavelengths classified as infrared, visible or ultraviolet light.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">behavioral response to light</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001632 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001632">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
+        <nbo:IAO_0000115>&quot;Behavior as a result of a chemical stimulus.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">behavioral response to chemical stimulus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001679 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001679">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001632"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/chebi#has_role"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35703"/>
+                            </owl:Restriction>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001632"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/chebi#has_role"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_35703"/>
+                    </owl:Restriction>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior as a result of a xenobiotic compound (compound foreign to living organisms) stimulus.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">behavioral response to xenobiotics</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001728 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001728">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001679"/>
+        <nbo:IAO_0000115>&quot;Behavior as a result of sensitivity to an addictive substance intake.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">behavioral response to addictive substance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001763 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001763">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001728"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000131"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001728"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000131"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior as a result of sensitivity to cocaine alcohol.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <rdfs:label xml:lang="en">behavioral response to alcohol</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001786 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001786">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of behavior, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [GO:0050795]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <oboInOwl:xref>GO:0050795</oboInOwl:xref>
+        <rdfs:label xml:lang="en">regulation of behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001824 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001824">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000131"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000064"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of alcohol consumption, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of alcohol consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001845 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001845">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the intake of substances.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <oboInOwl:hasBroadSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ingest</oboInOwl:hasBroadSynonym>
+        <rdfs:label xml:lang="en">consumption behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001884 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001884">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
+        <nbo:IAO_0000115>&quot;Behavior related to the intake of addictive substances.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">consumption of an addictive substance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001915 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001915">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001884"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27958"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001884"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27958"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the intake of cocaine.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">cocaine consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001952 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001952">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001884"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17303"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001884"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_17303"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the intake of morphine.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">morphine consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0001987 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0001987">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001728"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001915"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001728"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001915"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior as a result of sensitivity to cocaine intake.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <oboInOwl:xref>GO:0048148</oboInOwl:xref>
+        <rdfs:label xml:lang="en">behavioral response to cocaine</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002021 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002021">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001728"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001952"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001728"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001952"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior as a result of sensitivity to morphine&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">behavioral response to morphine</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002065 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002065">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001728"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0002086"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001728"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0002086"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior as a result of sensitivity to nicotine intake.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <oboInOwl:xref>GO:0035095</oboInOwl:xref>
+        <rdfs:label xml:lang="en">behavioral response to nicotine</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002086 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002086">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0001884"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_18723"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001884"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_18723"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Behavior related to the intake of nicotine.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">nicotine consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002132 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002132">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001915"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002234"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of cocaine consumption, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of cocaine consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002169 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002169">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001786"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of consumption behavior, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of consumption behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002234 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002234">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001884"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002169"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of consumption of an addictive substance, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of consumption of an addictive substance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002273 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002273">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0002086"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002234"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of nicotine consumption, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of nicotine consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002308 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002308">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001952"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002234"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of morphine consumption, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of morphine consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002362 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002362">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001679"/>
+        <nbo:IAO_0000115>&quot;Behavior as a result of sensitivity to an anasthetic intake.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">behavioral response to anesthetic</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002379 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002379">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000152"/>
+        <nbo:IAO_0000115>&quot;Maternal behavior related to the nursing offspring.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <rdfs:label xml:lang="en">nursing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002436 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002436">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000134"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002169"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of consumption of food or liquid&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of feeding behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002468 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002468">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000132"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000064"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of water consumption, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of water consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002511 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002511">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000136"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000063"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of saccharin consumption, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of saccharin consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002519 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002519">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000056"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000064"/>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
+                                <owl:someValuesFrom>
+                                    <owl:Class>
+                                        <owl:intersectionOf rdf:parseType="Collection">
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000381"/>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#qualifier"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001863"/>
+                                            </owl:Restriction>
+                                            <owl:Restriction>
+                                                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/pato#towards"/>
+                                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000130"/>
+                                            </owl:Restriction>
+                                        </owl:intersectionOf>
+                                    </owl:Class>
+                                </owl:someValuesFrom>
+                            </owl:Restriction>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000993"/>
+        <nbo:IAO_0000115>&quot;A pathological drinking behavior characterised by a lack of desire to drink.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <oboInOwl:xref>MP:0001428</oboInOwl:xref>
+        <rdfs:label xml:lang="en">adipsia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002569 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002569">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#in_response_to"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001305"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;Increase in core body termperature in response to stress or anticipatory anxiety.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">stress-induced hypothermia</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002603 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002603">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001786"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of sexual activity, the specific actions or reactions of an organism in response to external or internal stimuli.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of sexual activity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002660 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002660">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000064"/>
+        <nbo:IAO_0000115>&quot;A regulation of drinking behavior process associated with the preference over the type of liquids that are consumed. &quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of drinking preference behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002702 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002702">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002660"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16236"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002660"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_16236"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A regulation of drinking behavior process associated with the preference over alchohol consumption. &quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of alcohol preference behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002743 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002743">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000063"/>
+        <nbo:IAO_0000115>&quot;A regulation of drinking behavior process associated with the preference over the type of food that is consumed. &quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of eating preference behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002794 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002794">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0002743"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32111"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002743"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_32111"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A regulation of drinking behavior process associated with the preference over saccharing consumption. &quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of saccharin preference behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002869 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002869">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002234"/>
+        <nbo:IAO_0000115>&quot;A regulation of consumption of an addictive sustance behavior process associated with the preference over the type of addictive sustance that is consumed. &quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of addictive substance consumption preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002916 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002916">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002132"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002869"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/CHEBI_27958"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <nbo:IAO_0000115>&quot;A regulation of consumption of an addictive sustance behavior process associated with the preference over cocaine consumption. &quot; [NBO:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of cocaine consumption preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002948 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002948">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002603"/>
+        <nbo:IAO_0000115>&quot;A regulation of sexual activity process associated with the preference over a males or females.&quot; [NBO:GVG]</nbo:IAO_0000115>
+        <rdfs:label xml:lang="en">regulation of mating preference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002950 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002950">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000416"/>
+        <nbo:IAO_0000115>A vestibular reflex by which a response to an angular acceleration stimulus begins with an afferent nerve impulse from a receptor in the semi-circular canal and ends with the compensatory action of eye muscles. Signaling never reaches a level of consciousness. [GOC:dph]</nbo:IAO_0000115>
+        <oboInOwl:xref>GO:0060006</oboInOwl:xref>
+        <rdfs:label xml:lang="en">angular vestibuloocular reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002952 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002952">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000416"/>
+        <nbo:IAO_0000115>A vestibular reflex by which a response to a linear acceleration stimulus begins with an afferent nerve impulse from a receptor in the otolith and ends with the compensatory action of eye muscles. [GOC:dph]</nbo:IAO_0000115>
+        <oboInOwl:xref>GO:0060007</oboInOwl:xref>
+        <rdfs:label xml:lang="en">linear vestibuloocular reflex</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0002986 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0002986">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001728"/>
+        <nbo:IAO_0000115>Behavior response to addictive substance resulting from the discontinuation of an addictive substance. [NBOC:GVG]</nbo:IAO_0000115>
+        <rdfs:label xml:lang="en">withdrawal response</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0003047 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0003047">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001632"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001786"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of behavioral response to chemical stimulus.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of behavioral response to chemical stimulus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0003104 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0003104">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0001728"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0003047"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of behavioral response to chemical stimulus.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of behavioral response to addictive substance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0003142 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0003142">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0002986"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0003104"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of withdrawal response.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of withdrawal response</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0003161 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0003161">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001728"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002234"/>
+        <nbo:IAO_0000115>Behavior response to an addictive substance resulting from dependence of that addictive substance as well as unctronllable cravings of that substance. [NBOC:GVG]</nbo:IAO_0000115>
+        <rdfs:label xml:lang="en">addiction response</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0003194 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0003194">
+        <owl:equivalentClass>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002211"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0003161"/>
+            </owl:Restriction>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0003104"/>
+        <nbo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of withdrawal response.&quot; [NBOC:GVG]</nbo:IAO_0000115>
+        <nbo:created_by>George Gkoutos</nbo:created_by>
+        <rdfs:label xml:lang="en">regulation of addiction response</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020282"/>
+        <nbo:IAO_0000115 xml:lang="en">Consumption of specific compounds that facilitate processing of food items.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">aiding digestion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020010 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020010">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020084"/>
+        <nbo:IAO_0000115 xml:lang="en">Assessment of cues and signals from encountered individual to determine reproductive condition.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">reproductive status assessment</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020015 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020015">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Postures or signals that alert other animals to presence or approach of a predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">warn other prey</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020018 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020018">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior in which one animal causes the death of another.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <oboInOwl:hasExactSynonym xml:lang="en">killing</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">kill</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020023 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020023">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000147"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/NBO_0020242"/>
+        <nbo:IAO_0000115 xml:lang="en">Signal or behavior that reveals presence of the signaller directed to multiple receivers and not limited to particular receivers.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">broadcast advertisement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020031 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020031">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Threat that will not be acted upon.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">bluff</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020033 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020033">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Agonistic behavior involving direct physical contact including (but not limited to) biting, kicking, grabbing.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">contact aggression</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020034 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020034">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020177"/>
+        <nbo:IAO_0000115 xml:lang="en">Perform behaviors that may induce one or more other animals to share food with the performer.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">beg food</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020037">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Surveillance for presence or approach of predators.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">vigilance</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020040 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020040">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020292"/>
+        <nbo:IAO_0000115 xml:lang="en">Active pursuit of fleeing prey.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">chase prey</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020045 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020045">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020292"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors in which predator forces potential prey to emerge from cover.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">flush prey</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020047 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020047">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020298"/>
+        <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/NBO_0020109"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior associated with deposition of material by male following ejaculation to block access to female&apos;s reproductive tract during her future matings.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">insert genital plug</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020048 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020048">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
+        <nbo:IAO_0000115 xml:lang="en">Deposition of eggs either into the medium, or onto a substrate.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">facilitating oviposition</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020054 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020054">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000078"/>
+        <nbo:IAO_0000115 xml:lang="en">One member of a recently mating pair prevents the other from subsequent matings with other individuals.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mate guarding</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020059 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020059">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Currently reside in constructed or existing structure that provides reduced predator and/or environmental risk.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">occupy refuge</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020063 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020063">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Forcible alteration of behavior of one animal by another.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">coercion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020066 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020066">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
+        <nbo:IAO_0000115 xml:lang="en">Facilitating release or transfer of gametes.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">gamete release function</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020068 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020068">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020282"/>
+        <nbo:IAO_0000115 xml:lang="en">Caching or hoarding of food for later use and for protection from competitors, or use of specific substrates for cultivation.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">food storage</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020071 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020071">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000078"/>
+        <nbo:IAO_0000115 xml:lang="en">Displays or other behaviors performed by pairs in longer term pair bonds to advertise relationship to each other and to other animals nearby.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">pair affirmation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020077 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020077">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Performance of behaviors that demonstrate physical condition of performer to a detected predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">display condition (to predator)</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020079 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020079">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Emission of signals in such a way as to prevent effective use of signals emitted by other parties.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">jamming</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020084 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020084">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
+        <nbo:IAO_0000115 xml:lang="en">Active search for possible mates.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mate finding behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020088 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020088">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
+        <nbo:IAO_0000115 xml:lang="en">Postures or signals performed to other animals to indicate the presence, and in some cases, the location, quantity, and quality, of a resource.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">resource advertisement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020091 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020091">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020291"/>
+        <nbo:IAO_0000115 xml:lang="en">Sensory assessment of a resource (usually using olfaction or taste), for suitability of subsequent usage.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">suitability assessment</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020093 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020093">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">A behavior on the part of one individual associated with evaluating the fighting ability or correlates of fighting ability of a potential opponent.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">assessment behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020096 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020096">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020188"/>
+        <nbo:IAO_0000115 xml:lang="en">Locomotion to a resource guided by visual or olfactory cues created by a prior finder and/or user of that resource.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">trail following to resource</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020098 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020098">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior by one animals soliciting food provision by a potential mate.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">courtship begging</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020101 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020101">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
+        <nbo:IAO_0000115 xml:lang="en">Consumption of one member of a mating pair, usually the male, usually after the mating.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">sexual cannibalism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020102 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020102">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000078"/>
+        <nbo:IAO_0000115 xml:lang="en">Process of retaining developing eggs in the mouth cavity.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mouth brooding</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020105 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020105">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Construction of a structure in which builder can benefit from reduced predation risk and/or environmental stress.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">create refuge</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020108 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020108">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior that signifies hostility and predicts an increased probability of attack.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">threat</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020109 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020109">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020298"/>
+        <nbo:IAO_0000115 xml:lang="en">Use of specialized male organs to remove sperm already deposited in female&apos;s reproductive tract.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">sperm scraping</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020111 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020111">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior in which one animal causes bodily damage to another.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <oboInOwl:hasExactSynonym xml:lang="en">injuring</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">injure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020112 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020112">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Carrying or manipulation of infants or equivalent items to reduce chances of aggression on carrier by other animals.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">agonistic buffering</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020117 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Use of behavioral tactics or chemical weapons to deter predation. Example: flashing eye spots (behavioral tactic) or expulsion of noxious liquid (chemical).</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">deploy defense</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020121 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020121">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000060"/>
+        <nbo:IAO_0000115 xml:lang="en">Insertion of sperm not in a spermatophore into female body.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">insemination</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020137 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020137">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020292"/>
+        <nbo:IAO_0000115 xml:lang="en">Building of a trap, web, net, or other structure to help ensnare potential food items.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">construct capturing device</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020139 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020139">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors that reduce detectability of performer against background.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">enhance crypsis</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020141 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020141">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Chasing of one animal by another during an agonistic conflict.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">agonistic chase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020142 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020142">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020282"/>
+        <nbo:IAO_0000115 xml:lang="en">The identification, avoidance, or neutralization of toxic substances in food.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">dealing with toxins</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020144 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020144">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020188"/>
+        <nbo:IAO_0000115 xml:lang="en">Removal of food resource from previously-stored supply of food.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">recovery from cache</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020145 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020145">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000470"/>
+        <nbo:IAO_0000115 xml:lang="en">Alarm behavior triggered by agonistic actions or postures</nbo:IAO_0000115>
+        <nbo:IAO_0000115 xml:lang="en">Alarm behavior triggered by agonistic actions or postures.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">agonistic alarm</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020149 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020149">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Signals emitted by an animal trapped or captured by a presumed predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">distress signaling</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020159 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020159">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000051"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors that serve to reduce body temperature as by moving to shade or panting.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">cooling behaviour</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020160 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020160">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020292"/>
+        <nbo:IAO_0000115 xml:lang="en">Approach to prey in manner designed to avoid early detection by prey.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">stalk prey</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020170 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020170">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020188"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors that reveal a hidden food resource, such as digging, cracking, or breaking.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">food exposure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020173 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020173">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020177"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors in which animals solicit or allow other animals to utilize a resource they currently control.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">share food</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020174 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020174">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020066"/>
+        <nbo:IAO_0000115 xml:lang="en">Release of gametes one or both sexes into the ambient medium.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">spawning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020175 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020175">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Halting or diminution of activity to minimize detection by predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">reduce activity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020177 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020177">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
+        <nbo:IAO_0000115 xml:lang="en">Obtaining food that has been procured by other conspecifics or heterospecifics.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">social acquisition of food</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020182 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020182">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Increasing intensity of directed agonistic behavior.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">escalation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020188 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020188">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
+        <nbo:IAO_0000115 xml:lang="en">Movement directed to the detection of new resources.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">nutrient locating</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020199 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020199">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Become immobile and reduce other evidence of living state.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">feign death</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020204 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020204">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020066"/>
+        <nbo:IAO_0000115 xml:lang="en">Spawning in which male and female are clasped or attached to ensure close proximity of released gametes</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mating amplexus</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020219 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020219">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors directed towards presumed predators to redirect their attention away from a location of importance to the performer.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">misdirect predator</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020220 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020220">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior that serves to exlude an animal from a group.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">exclusion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020223 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020223">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Conspicuous orientation towards and/or approach to detected predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">inspect predator</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020230 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020230">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Perform physically violent acts on a presumed predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">attack predator</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020239 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020239">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Display behavior by the winner of a prior agonistic contest.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">triumph</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020241 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000146"/>
+        <nbo:IAO_0000115 xml:lang="en">Performance of a behavior that indicates the performer&apos;s willingness to mate or bond</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mating solicitation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020242 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020242">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000147"/>
+        <nbo:IAO_0000115 xml:lang="en">Creation of or modification of a structure or area that is used in attraction of mates.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">build display structure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020245 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020245">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors, anatomical structures, or signals that imitate aposematic animals, plants, or inanimate objects that are undesirable to predators of performer.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mimicry enhancement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020251 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020251">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Erratic movements or similar behaviors that would confuse a predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">promote confusion</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020253 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020253">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior that serves to demonstrate non-aggressive intent by one member of a courting or potentially mating pair to the other.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mating appeasement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020254 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020254">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
+        <nbo:IAO_0000115 xml:lang="en">Any of several behaviors directed towards one animal unwilling to mate by another eager to do so.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">sexual harassment</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020255 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020255">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">An acitvity that seems irrelevant to its behavioral context to a human observer and often occurs when its performer is in a conflict situation.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">displacement behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020264 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020264">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
+        <nbo:IAO_0000115 xml:lang="en">Provision of food to a potential mate</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">courtship feeding</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020266 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020266">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020066"/>
+        <nbo:IAO_0000115 xml:lang="en">Deposition of spermatophore either on substrate or in body of female.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">spermatophore deposition</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020268 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020268">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Depart [from] current location of predator.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">flee</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020272 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020272">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020084"/>
+        <nbo:IAO_0000115 xml:lang="en">Active searching of potential mate</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">hunt for mate</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020273 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020273">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000014"/>
+        <nbo:IAO_0000115 xml:lang="en">Actions resulting in establishment or use of one locale for reproductive activity.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">breeding site selection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020279 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020279">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors that appear to signifiy lack of hostility and to reduce chances of attack.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">appeasement</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020281 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020281">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020084"/>
+        <nbo:IAO_0000115 xml:lang="en">General category of behaviors including sampling of medium to detect presence of possible mates, and sampling of encountered individuals to determine mate suitability.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mate sampling</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020282 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020282">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors related to acquisition and utilization of external resources.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">nutrient acquisition</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020286 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020286">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020291"/>
+        <nbo:IAO_0000115 xml:lang="en">Removal of food items from location by use of appendage or tool.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">food extraction</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020287 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020287">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Conspicuous postures or signals (often coloration) that potential predators learn to associate with strong defense mechanisms of performer</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">aposematism</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020289 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020289">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
+        <nbo:IAO_0000115 xml:lang="en">Postures or signals that can communicate to predator that it has been detected by performer.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">(predator) detection notification</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020291 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020291">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior that precedes and facilitates attaining food.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">nutrient preparation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020292 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020292">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0002120"/>
+        <nbo:IAO_0000115 xml:lang="en">Suite of behaviors involved in securing a prey item once it has been located.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">capturing behaviour</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020293 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020293">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020292"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors that result in ending flight of prey with successful predation.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">capturing prey</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020294 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020294">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020068"/>
+        <nbo:IAO_0000115 xml:lang="en">The act of putting a food resource in a location in which it can be stored or protected until a future time.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">caching behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020295 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020295">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020291"/>
+        <nbo:IAO_0000115 xml:lang="en">Behaviors that prepare food for consumption, such as nut-cracking or peeling.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">food processing</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020296 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020296">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020177"/>
+        <nbo:IAO_0000115 xml:lang="en">Uninvited taking of food from another animal.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">scrounge</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020297 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020297">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0020177"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior associated with locating and acquiring food that has been killed or procured by another animal.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">scavenge</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020298 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020298">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
+        <nbo:IAO_0000115 xml:lang="en">Usually interference by members of one sex in the completion of courtship or mating activities by one or more members of the same sex.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">sexual interference</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0020299 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0020299">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
+        <nbo:IAO_0000115 xml:lang="en">Behavior associated with refusing courtship or solicitation behaviors by avoidance, retreat, or other active repulsion of suitor.</nbo:IAO_0000115>
+        <nbo:created_by rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Luke Slater</nbo:created_by>
+        <rdfs:label xml:lang="en">mate rejection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0050000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0050000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
+        <nbo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A feeding behavior during which an animal ingests biomass produced by a plant or other primary producer</nbo:IAO_0000115>
+        <nbo:created_by>http://orcid.org/0000-0002-1816-4260</nbo:created_by>
+        <nbo:created_by>http://orcid.org/0000-0002-4366-3088</nbo:created_by>
+        <nbo:namespace>behavior_ontology</nbo:namespace>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-09-14T19:12:10+09:00</dc:date>
+        <oboInOwl:hasDbXref>https://en.wikipedia.org/wiki/Grazing</oboInOwl:hasDbXref>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grazing behaviour</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000001"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000014 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000014">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001300"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000040 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000040">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001018"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000044 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000044">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000161"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000047 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000047">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001995"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000051 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000051">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001241"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000052 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000052">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000051"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000069 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000069"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000117 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000117">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000051"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000125 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000125">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001018"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000145 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000145"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000146 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000146">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001018"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000161 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000161">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002062"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000186 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000186">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001995"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000188 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000188">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000186"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000380 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000380">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000044"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000912"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000381 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000381">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000044"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000911"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000770 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000770">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000188"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000911 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000911">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000161"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002302"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000912 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000912">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000161"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002304"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001018 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001018">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001241"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001025 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001025">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001018"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001236 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001236">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001241 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001291 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001291">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001739"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001300 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001300">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001291"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000146"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002305"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001306 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001306">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000146"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002303"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001309 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001309">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002062"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001333 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001333">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002304"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002324"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001558 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001558">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001564"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001563 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001563">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000125"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002305"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001564 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001564">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001236"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001595 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001595">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001708"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001708 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001708">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000117"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001727 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001727">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001241"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001739 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001739"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001863 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001863">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001309"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001894 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001894">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000047"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001995 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001995">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001241"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002062 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001236"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002300 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002300">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000069"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002301 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002301">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000069"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002302 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002302">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001236"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002301"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002303 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002303">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001241"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002301"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002304 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002304">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001236"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002300"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002305 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002305">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001241"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002300"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002323 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002323">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002062"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002324 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002324">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002323"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002360 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002360">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001727"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002361 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002361">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002305"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002360"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000026 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000026">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000475"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000060 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000060">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000064"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000061 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000061">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000062 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000064 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000064"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000077 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000077">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004119"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004120"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000078 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000078">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000077"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004121"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000309 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000309">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000060"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0009569"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000465 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000467 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000467">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000480"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000475 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000475"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000480 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000480">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001032 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001032">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000467"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001033 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001033">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000467"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001256 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001256">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000060"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000078"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006554"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001817 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001817">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002365"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0003297"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004859"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0015154"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002097 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002097">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000062"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004121"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002101 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002101">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004708"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002104 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002104">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001032"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002105 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002105">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001032"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002204 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002204">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000467"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002365 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002365">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002530 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002530">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000062"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0003297 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0003297"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004119 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004119">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004120 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004120">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004121 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004121">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004681 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004681">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001032"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004708 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004708">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000026"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004859 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004859">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004121"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0005725 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005725">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005726"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0005726 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005726">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001032"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0006554 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006554">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0009569 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0009569">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000475"/>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0010000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0015154 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0015154"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo.owl#NBO_0009001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/nbo.owl#NBO_0009001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
+        <rdfs:label xml:lang="en">rotation behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/nbo.owl#NBO_0009002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/nbo.owl#NBO_0009002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
+        <nbo:IAO_0000115>Deactiviation of locomotory behavior.</nbo:IAO_0000115>
+        <rdfs:label xml:lang="en">locomotor inactivation behavior</rdfs:label>
+    </owl:Class>
+    <rdf:Description>
+        <nbo:synonymtype>EXACT</nbo:synonymtype>
+    </rdf:Description>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007625">
+        <oboInOwl:hasExactSynonym xml:lang="en">groom</oboInOwl:hasExactSynonym>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_0007629">
+        <oboInOwl:hasExactSynonym xml:lang="en">fly</oboInOwl:hasExactSynonym>
+    </rdf:Description>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000014"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000034"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000078"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020084"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020254"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020298"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020299"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000048"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000087"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020015"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020031"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020037"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020059"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020077"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020079"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020105"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020117"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020139"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020149"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020175"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020199"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020223"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020230"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020245"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020251"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020268"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020287"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020289"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000060"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000548"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000549"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020048"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020066"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000077"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000146"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000147"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020273"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000089"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000237"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020088"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020177"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020188"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020282"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020291"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000122"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000127"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000128"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000296"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000743"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020018"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020033"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020063"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020093"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020108"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020111"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020112"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020141"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020145"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020182"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020220"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020239"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020255"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020279"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000637"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0000638"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020098"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020101"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020253"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020264"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020007"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020068"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020142"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020010"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020272"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020281"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020034"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020173"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020296"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020297"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020040"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020045"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020137"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020160"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020293"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020054"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020071"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020102"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020091"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020286"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020295"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020096"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020144"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020170"/>
+        </owl:members>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
+        <owl:members rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020174"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020204"/>
+            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NBO_0020266"/>
+        </owl:members>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.2.6) https://github.com/owlcs/owlapi -->
+

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -17,10 +17,10 @@ SPARQLDIR = ../sparql
 # Top-level targets
 # ----------------------------------------
 
-all: sparql_test all_imports $(ONT).owl $(ONT).obo
+all: sparql_test all_imports $(ONT).owl $(ONT).obo $(ONT)-base.owl
 test: sparql_test all
 prepare_release: all
-	cp $(ONT).owl $(RELEASEDIR) &&\
+	cp $(ONT).owl $(ONT)-base.owl $(RELEASEDIR) &&\
 	mkdir -p $(RELEASEDIR)/imports &&\
 	cp imports/*{owl,obo} $(RELEASEDIR)/imports &&\
 	git add $(RELEASEDIR)/imports/*{obo,owl} &&\
@@ -37,7 +37,9 @@ $(ONT).owl: $(SRC)
 	$(ROBOT)  reason -i $< -r ELK relax reduce -r ELK annotate -V $(BASE)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
 $(ONT).obo: $(ONT).owl
 	$(ROBOT) convert -i $< -f obo -o $(ONT).obo.tmp && mv $(ONT).obo.tmp ../../$(ONT).obo
-
+	
+$(ONT)-base.owl: $(SRC)
+	$(ROBOT) remove --trim false --input $< --select imports annotate --ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ --output $@
 # ----------------------------------------
 # Import modules
 # ----------------------------------------
@@ -69,7 +71,7 @@ mirror/%.owl: $(SRC)
 # Release
 # ----------------------------------------
 # copy from staging area (this directory) to top-level
-release: $(ONT).owl $(ONT).obo
+release: $(ONT).owl $(ONT)-base.owl $(ONT).obo
 	cp $^ $(RELEASEDIR) && cp imports/* $(RELEASEDIR)/imports
 
 # ----------------------------------------


### PR DESCRIPTION
This pull request contains two changes:
1) The **Makefile** contains now a new target called nbo-base, which generates a minimal version of the NBO without any of its imports. This product is used now in more places in the OBO world, as a means to deal with incompatible imports (versions)
2) the actual **nbo-base**. I ran the NBO release (make prepare_release), but decided that for now, I will only add the nbo-base and not all other updated release products. is make prepare_release the only thing you run to generate a new version of NBO? If you want, I can push the updated NBO version (owl, obo) as well. 