### PR TITLE
Changed all instances of PATO:liquid substance to  PATO:quality of liquid

### DIFF
--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -2903,7 +2903,7 @@
                             </owl:Restriction>
                             <owl:Restriction>
                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
-                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001548"/>
                             </owl:Restriction>
                         </owl:unionOf>
                     </owl:Class>
@@ -3630,7 +3630,7 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/nbo#has_participant"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001548"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <IAO_0000115>&quot;A behavior associated with the intake of liquid.&quot; [NBO:GVG]</IAO_0000115>
@@ -10222,7 +10222,7 @@
                                         <owl:someValuesFrom>
                                             <owl:Class>
                                                 <owl:intersectionOf rdf:parseType="Collection">
-                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001548"/>
                                                     <owl:Restriction>
                                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
                                                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001563"/>
@@ -14314,7 +14314,7 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
                                 <owl:someValuesFrom>
                                     <owl:Class>
                                         <owl:intersectionOf rdf:parseType="Collection">
-                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                                            <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001548"/>
                                             <owl:Restriction>
                                                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
                                                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001563"/>
@@ -14352,7 +14352,7 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
                                         <owl:someValuesFrom>
                                             <owl:Class>
                                                 <owl:intersectionOf rdf:parseType="Collection">
-                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000145"/>
+                                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001548"/>
                                                     <owl:Restriction>
                                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/uberon#has_quality"/>
                                                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0001563"/>


### PR DESCRIPTION
PATO:0000145 ('obsolete liquid substance') is obsolete. The recommended replacement for most cases is PATO:0001548 ('quality of a liquid'). This PR replaces the instances of the former with the latter.

The fix is important because as per quality standards, our phenotype ontologies cannot have obsoleted classes used in axioms. 

The following axioms are affected:
```
Obsolete class PATO:0000145 'obsolete liquid substance' in axiom: EquivalentClasses(NBO:0000886 'increased amount of liquid in drinking regulation' ObjectSomeValuesFrom(BFO:0000056 'participates in' ObjectIntersectionOf(NBO:0000064 'regulation of drinking behavior' ObjectSomeValuesFrom(RO:0002211 'regulates' ObjectSomeValuesFrom(has-input 'has-input' ObjectIntersectionOf(PATO:0000145 'obsolete liquid substance' ObjectSomeValuesFrom(has_quality has_quality PATO:0001563 'increased mass')))))))
Obsolete class PATO:0000145 'obsolete liquid substance' in axiom: EquivalentClasses(NBO:0000851 'increased amount of liquid in a single drinking act' ObjectSomeValuesFrom(BFO:0000056 'participates in' ObjectIntersectionOf(GO:0042756 'drinking behavior' ObjectSomeValuesFrom(has-input 'has-input' ObjectIntersectionOf(PATO:0000145 'obsolete liquid substance' ObjectSomeValuesFrom(has_quality has_quality PATO:0001563 'increased mass'))))) )
Obsolete class PATO:0000145 'obsolete liquid substance' in axiom: SubClassOf(NBO:0000130 'liquid consumption' ObjectSomeValuesFrom(has_participant 'has_participant' PATO:0000145 'obsolete liquid substance'))
Obsolete class PATO:0000145 'obsolete liquid substance' in axiom: EquivalentClasses(NBO:0000542 'polydipsia' ObjectSomeValuesFrom(BFO:0000056 'participates in' ObjectIntersectionOf(ObjectIntersectionOf(NBO:0000064 'regulation of drinking behavior' ObjectSomeValuesFrom(RO:0002211 'regulates' NBO:0000130 'liquid consumption') ObjectSomeValuesFrom(has-input 'has-input' ObjectIntersectionOf(PATO:0000145 'obsolete liquid substance' ObjectSomeValuesFrom(has_quality has_quality PATO:0001563 
Obsolete class PATO:0000145 'obsolete liquid substance' in axiom: EquivalentClasses(NBO:0000079 'feeding behavior' ObjectIntersectionOf(NBO:0001845 'consumption behavior' ObjectUnionOf(ObjectSomeValuesFrom(has_participant 'has_participant' CHEBI:33290 'food') ObjectSomeValuesFrom(has_participant 'has_participant' PATO:0000145 'obsolete liquid substance'))) )

```