### PR TITLE
Removal of obsolete GO classes 

### DIFF
--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -16686,7 +16686,6 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0001256">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000060"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000078"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006554"/>
     </rdf:Description>
     
 
@@ -16821,16 +16820,6 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0005726">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001032"/>
     </rdf:Description>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/UBERON_0006554 -->
-
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0006554">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
-    </rdf:Description>
-    
-
 
     <!-- http://purl.obolibrary.org/obo/UBERON_0009569 -->
 

--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -726,9 +726,7 @@
 
     <!-- http://purl.obolibrary.org/obo/GO_0003008 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0003008">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0003008"/>
     
 
 
@@ -923,7 +921,6 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007632">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009416"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044704"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
     </owl:Class>
     
 
@@ -1136,9 +1133,7 @@
 
     <!-- http://purl.obolibrary.org/obo/GO_0030431 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0030431">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0030431"/>
     
 
 
@@ -1262,17 +1257,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044705"/>
     
-
-
-    <!-- http://purl.obolibrary.org/obo/GO_0044707 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044707">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0032501"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044699"/>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0044708 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044708">
@@ -1352,7 +1336,6 @@
     <!-- http://purl.obolibrary.org/obo/GO_0050878 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050878">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0065008"/>
     </owl:Class>
     
@@ -1360,9 +1343,7 @@
 
     <!-- http://purl.obolibrary.org/obo/GO_0050879 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050879">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044707"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0050879"/>
     
 
 

--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -885,7 +885,6 @@
     <!-- http://purl.obolibrary.org/obo/GO_0007622 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007622">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0048511"/>
     </owl:Class>
     
@@ -902,7 +901,6 @@
     <!-- http://purl.obolibrary.org/obo/GO_0007626 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007626">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
         <oboInOwl:hasExactSynonym xml:lang="en">locomotion</oboInOwl:hasExactSynonym>
     </owl:Class>
     
@@ -929,7 +927,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007635">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0042221"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
     </owl:Class>
     
 
@@ -938,7 +935,6 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0007638">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009612"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
     </owl:Class>
     
 
@@ -1248,7 +1244,6 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044704">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0019098"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044702"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
     </owl:Class>
     
 
@@ -1256,14 +1251,6 @@
     <!-- http://purl.obolibrary.org/obo/GO_0044705 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044705"/>
-    
-    <!-- http://purl.obolibrary.org/obo/GO_0044708 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044708">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007610"/>
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044699"/>
-    </owl:Class>
-    
 
     <!-- http://purl.obolibrary.org/obo/GO_0045297 -->
 
@@ -1634,9 +1621,7 @@
 
     <!-- http://purl.obolibrary.org/obo/GO_0060273 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060273">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044708"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0060273"/>
     
 
 

--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -1281,13 +1281,6 @@
     </owl:Class>
     
 
-
-    <!-- http://purl.obolibrary.org/obo/GO_0044765 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044765"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0045297 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0045297">
@@ -1299,9 +1292,7 @@
 
     <!-- http://purl.obolibrary.org/obo/GO_0046903 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0046903">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044765"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0046903"/>
     
 
 

--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -1218,15 +1218,6 @@
     </owl:Class>
     
 
-
-    <!-- http://purl.obolibrary.org/obo/GO_0044699 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044699">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0008150"/>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/GO_0044702 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0044702"/>
@@ -1269,9 +1260,7 @@
 
     <!-- http://purl.obolibrary.org/obo/GO_0048511 -->
 
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0048511">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0044699"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/GO_0048511"/>
     
 
 


### PR DESCRIPTION
In order for our ontologies that depend on NBO to pass QC, we need to remove obsolete classes from axioms. Usually, we would replace the occurrence of an obsolete class with one of its recommended replacements. In the case of NBO, however, axioms using obsolete classes where without exceptions GO axioms - these should come from GO and remain there. For example, nbo-edit.owl physically contains axioms such as GO:1 subclass of GO:2. This should be avoided at all costs, because of the overhead this creates for curating GO:axioms twice (once in GO, which is imported; once in NBO). 