### PR TITLE
Added cannabis consumption and tobacco consumption terms. #98

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - docker pull obolibrary/odkfull
 
 # command to run tests
-script: cd src/ontology && sh run.sh make test
+script: cd src/ontology && sh run.sh make IMP=false prepare_release
 
 #after_success:
 #  coveralls

--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -3,7 +3,6 @@
      xml:base="http://purl.obolibrary.org/obo/nbo.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:go="http://purl.obolibrary.org/obo/go#"
-     xmlns:nbo="http://purl.obolibrary.org/obo/nbo.owl#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"

--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -1,16 +1,27 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://purl.obolibrary.org/obo/nbo.owl#"
-     xml:base="http://purl.obolibrary.org/obo/nbo.owl"
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/nbo.owl/"
+     xml:base="http://purl.obolibrary.org/obo/nbo.owl/"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:go="http://purl.obolibrary.org/obo/go#"
+     xmlns:nbo="http://purl.obolibrary.org/obo/nbo.owl#"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:cito="http://purl.org/spar/cito/"
+     xmlns:core="http://purl.obolibrary.org/obo/uberon/core#"
      xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:pato="http://purl.obolibrary.org/obo/pato#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:chebi="http://purl.obolibrary.org/obo/chebi/"
+     xmlns:core1="http://purl.obolibrary.org/obo/core#"
+     xmlns:swrla="http://swrl.stanford.edu/ontologies/3.3/swrla.owl#"
      xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:chebi2="http://purl.obolibrary.org/obo/chebi#"
+     xmlns:chebi3="http://purl.obolibrary.org/obo/chebi#3"
+     xmlns:chebi4="http://purl.obolibrary.org/obo/chebi#1"
+     xmlns:subsets="http://purl.obolibrary.org/obo/ro/subsets#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/nbo.owl">
         <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/nbo/2018-05-11/nbo.owl"/>
@@ -41,12 +52,6 @@
     
 
 
-    <!-- http://www.geneontology.org/formats/oboInOwl#created_by -->
-
-    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/nbo.owl#synonymtype -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/nbo.owl#synonymtype"/>
@@ -56,6 +61,12 @@
     <!-- http://purl.org/dc/elements/1.1/date -->
 
     <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#created_by -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by"/>
     
 
 
@@ -572,8 +583,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A change of place or position of part of an organism that does not involve the entire organism [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>stationary movement</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body part movement</rdfs:label>
@@ -585,8 +596,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">whole body movement</rdfs:label>
     </owl:Class>
@@ -598,8 +609,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000003">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;Behavior related to the complex psychophysiological experience of an individual&apos;s state of mind as interacting with biochemical (internal) and environmental (external) influences.&quot; [wikipedia:Emotions]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>affective behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>mood</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -613,8 +624,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to involuntary movement in response to a stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:57:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pathological reflexive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reflexive behavior phenotype</rdfs:label>
@@ -627,8 +638,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000006">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000607"/>
         <obo:IAO_0000115>&quot;Behavior related to the acquisition and processing of information and/or the storage and retrieval of this information over time.&quot; [GO:jic]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>learning and/or memory behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007611</oboInOwl:xref>
@@ -642,8 +653,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000007">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving any of the tissues and hard structures surrounding the mouth other than teeth, jaws or filter structures [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mouth part movement</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">other moved mouth parts</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -656,8 +667,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007622</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhythmic behavior</rdfs:label>
@@ -686,8 +697,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior associated with the specific movement from place to place of an organism.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T12:58:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pathological locomotory behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotory behavior phenotype</rdfs:label>
@@ -700,8 +711,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000010">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior directly related to the production of offspring [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">reproduction</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>reproductive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -716,8 +727,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;A behavior that occurs predominantly or only, in individuals that are part of a group.&quot; [Wikipedia:Social_behavior]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>social behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0035176</oboInOwl:xref>
@@ -730,8 +741,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0001250</oboInOwl:xref>
         <oboInOwl:xref>MP:0002064</oboInOwl:xref>
@@ -746,8 +757,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0040011"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
         <obo:IAO_0000115>Movement from place to place of an organism.&quot; [GO:0007626]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">locomotion</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007626</oboInOwl:xref>
@@ -762,8 +773,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000014">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
         <obo:IAO_0000115>&quot;Behavior related to the interactions between organisms for the purpose of mating.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>mating behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007617</oboInOwl:xref>
@@ -777,8 +788,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000015">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <obo:IAO_0000115>&quot;A behavioral interaction between organisms in which one organism has the intention of inflicting damage on another individual using physical or verbal means.&quot; [wikipedia:Aggression]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>aggressive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>agonism</oboInOwl:hasExactSynonym>
@@ -794,8 +805,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000016">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
         <obo:IAO_0000115>&quot;Behavior relate to the usually upward movement off the ground or other surface through sudden muscular effort in the legs.&quot; [GO:0007630]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">jump</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007630</oboInOwl:xref>
@@ -809,8 +820,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000017">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of seizing with teeth or jaws an object or organism so as to grip or break the surface covering [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">bite</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biting</rdfs:label>
@@ -824,8 +835,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
         <obo:IAO_0000115>&quot;Emotional behavior related to fear or anxiety.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>fear/anxiety related behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear/anxiety related behavior</rdfs:label>
@@ -838,8 +849,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000019">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000748"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of stroking or touching with the tongue [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">lick</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">licking</rdfs:label>
@@ -852,8 +863,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000020">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A change in place or position of the portion of the organism containing the brain, mouth and main sense organs [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">move head</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head movement</rdfs:label>
@@ -866,8 +877,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000022">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000006"/>
         <obo:IAO_0000115>&quot;Behavior associated with any process in an organism in which a relatively long-lasting adaptive behavioral change occurs as the result of experience.&quot; [wikipedia:Learning]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>learning behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007612</oboInOwl:xref>
@@ -882,8 +893,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000068"/>
         <obo:IAO_0000115>&quot;Movement of the head in the horizontal plane.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">shake head</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head shaking</rdfs:label>
@@ -897,8 +908,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0030431"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000008"/>
         <obo:IAO_0000115>&quot;Behavior related to the readily reversible state of reduced awareness and metabolic activity that occurs periodically in many animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0030431</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleeping behavior</rdfs:label>
@@ -911,8 +922,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000025">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
         <obo:IAO_0000115>&quot;An uncontrolled, paroxysmal neuronal discharge in any part of the brain; it may cause physical or mental symptoms and may be convulsive or nonconvulsive&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>epileptic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>unprovoked seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -926,8 +937,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000026">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving the head in a plane, circularly, pivoting at the neck [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">rotate head</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">head rotation</rdfs:label>
@@ -940,8 +951,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000027">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of using body parts to pick at, rub and or remove material from exterior covering, e.g., fur, scales, feathers, skin [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">groom</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>grooming behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -957,8 +968,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000028">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
         <obo:IAO_0000115>&quot;Absence of voluntary movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T12:59:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">akinesia</rdfs:label>
     </owl:Class>
@@ -970,8 +981,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000029">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
         <obo:IAO_0000115>&quot;Reduction of voluntary movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hypokinesia</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bradykinesia</rdfs:label>
@@ -984,8 +995,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000030">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
         <obo:IAO_0000115>&quot;A kinesthetic behavior which relatively increased.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:09:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000752</oboInOwl:xref>
         <oboInOwl:xref>MP:0001399</oboInOwl:xref>
@@ -999,8 +1010,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000031">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
         <obo:IAO_0000115>&quot;A kinesthetic behavior which relatively decreased.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:09:41Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0001402</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypoactivity</rdfs:label>
@@ -1013,8 +1024,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000032">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
         <obo:IAO_0000115>&quot;Loss of power of voluntary movement in a muscle through injury or disease of its nerve supply.&quot; [JAX:&lt;new dbxref&gt;]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:18:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0003470</oboInOwl:xref>
         <oboInOwl:xref>MP:0000753</oboInOwl:xref>
@@ -1028,8 +1039,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000033">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
         <obo:IAO_0000115>&quot;Paralysis of the extensors of the wrist and fingers.&quot; [JAX:&lt;new dbxref&gt;]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:19:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0005162</oboInOwl:xref>
         <rdfs:comment>Carpoptosis is most often caused by a lesion of the radial nerve.</rdfs:comment>
@@ -1043,8 +1054,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000034">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
         <obo:IAO_0000115>&quot;Behaviour related to the activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual actions</oboInOwl:hasRelatedSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual activity</rdfs:label>
@@ -1056,8 +1067,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000035">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emission behavior</rdfs:label>
     </owl:Class>
@@ -1068,8 +1079,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000036">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000035"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">produce sound</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of production of sound</rdfs:label>
@@ -1082,8 +1093,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000037">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000036"/>
         <obo:IAO_0000115>&quot;A behavior in which an organism produces sounds by a mechanism involving its respiratory system.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>vocalization behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">vocalize</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1114,8 +1125,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;The elimination by an organism of the waste products that arise as a result of metabolic activity. These products include water, carbon dioxide (CO2), and nitrogenous compounds.&quot; [wikipedia:Excretion]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007588</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of excretion</rdfs:label>
@@ -1145,8 +1156,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The behavioral control of defecation. [wikipedia:defecation]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of defecation</rdfs:label>
     </owl:Class>
@@ -1185,8 +1196,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;The regulation of body fluids process by which parasympathetic nerves stimulate the bladder wall muscle to contract and expel urine from the body.&quot; [wikipedia:urination]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>micturition</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">urinate</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1218,8 +1229,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior associated with and resulting in the production and subsequent release of any substance or product elaborated, and released by a cell or gland [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">secrete</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of external secretion</rdfs:label>
@@ -1259,8 +1270,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;The regulated release of the aqueous layer of the tear film from the lacrimal glands.&quot; [wikipedia:lacrimation]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">tear release</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>tear secretion</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1274,8 +1285,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000043">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
         <obo:IAO_0000115>A behavior that occurs between two individuals, such as parent and child, and involves an emotional attachment that implies a special and focused relationship.</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>forming of peer relationship</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bonding behavior</rdfs:label>
@@ -1294,8 +1305,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000044">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior associated with protection, or assisting growth and development of young. [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0060746</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">parental behavior</rdfs:label>
@@ -1308,8 +1319,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000045">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000048"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior that serves to regulate the temperature around offspring.[NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermoregulation of offspring</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brooding behavior</rdfs:label>
@@ -1321,8 +1332,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000047">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>weaning behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">weaning behavior</rdfs:label>
@@ -1336,8 +1347,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
         <obo:IAO_0000115>&quot;Behavior related the protection of offspring.&quot; [NBO:SD]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">protection of offspring</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protection of offspring behavior</rdfs:label>
@@ -1351,8 +1362,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
         <obo:IAO_0000115>&quot;Play behavior that is associated with the socialization of an individual into the group.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Play%20Fighting.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000625</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>social playing behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1366,8 +1377,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000051">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
         <obo:IAO_0000115>&quot;Behavior related to the actions by which an organism modulates its internal body temperature.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermoregulation behavior</rdfs:label>
     </owl:Class>
@@ -1379,8 +1390,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000052">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000051"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior associated with two or more individuals&apos; achieving or maintaining close and extensive bodily contact; to nestle closely with another [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">huddle</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">huddling behavior</rdfs:label>
@@ -1393,8 +1404,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000053">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000051"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Exposure of body to sunlight, either by modification of body posture, by movement to specific areas or both [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">basking</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">sunning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">sunning behavior</oboInOwl:hasExactSynonym>
@@ -1409,8 +1420,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000054">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
         <obo:IAO_0000115>&quot;Specific actions of a newborn or infant mammal that result in the derivation of nourishment from the breast.&quot; [GOC:dph]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000046</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>nursing behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>suckling behaviour</oboInOwl:hasExactSynonym>
@@ -1426,8 +1437,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000055">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of locomoting on limbs with body off the ground such that periodically none of the limbs are touching the ground [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">run</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">running behavior</rdfs:label>
@@ -1440,8 +1451,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000056">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
         <obo:IAO_0000115 xml:lang="en">The act of locomoting on limbs with body off the ground such that at least one limb is always touching the ground [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">walking</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007628</oboInOwl:xref>
@@ -1455,8 +1466,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000057">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of dragging claws or nails over a surface [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">scratch</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">scratching behavior</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1469,8 +1480,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000059">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nuzzling</rdfs:label>
     </owl:Class>
@@ -1482,8 +1493,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000060">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Male&apos;s insertion of sperm-transfer organ into the body of the female [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:03:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">copulate</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">copulation</rdfs:label>
@@ -1496,8 +1507,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000061">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
         <obo:IAO_0000115>&quot;Loss of power of voluntary movement in muscles of the forelimb through injury or disease of it or its nerve supply.&quot; [JAX:]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0000756</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">forelimb paralysis</rdfs:label>
@@ -1510,8 +1521,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000062">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
         <obo:IAO_0000115>&quot;Behavior related to the washing or cleansing of the body in a fluid, usually water or an aqueous solution.&quot; [wikipedia:Bathing]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">bathe</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>bathing behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1531,8 +1542,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002436"/>
         <obo:IAO_0000115>&quot;A feeding behavior associated with the intake or the frequency of intake or preference or manner of intake of food.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>eating behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042755</oboInOwl:xref>
@@ -1552,8 +1563,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0002436"/>
         <obo:IAO_0000115>&quot;A feeding behavior associated with the intake or the frequency of intake or preference or manner of intake of liquids.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>drinking behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042756</oboInOwl:xref>
@@ -1567,8 +1578,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000065">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;Behavior related to a variety of aspects of the relationship between the mind and the world with which it interacts.&quot; [wikipedia:Consciousness]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">consciousness behavior</rdfs:label>
     </owl:Class>
@@ -1580,8 +1591,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000066">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000649"/>
         <obo:IAO_0000115>&quot;Behavior related to the state of being conscious and engages in a coherent cognitive and behavior responses to the external world.&quot; [NBO:SD, wikipedia:Wakefulness]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">wakefulness</rdfs:label>
     </owl:Class>
@@ -1593,8 +1604,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000067">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
         <obo:IAO_0000115>&quot;Behavior related to reduced or absent consciousness, relatively suspended sensory activity, and inactivity of nearly all voluntary muscles.&quot; [wikipedia:Asleep]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">asleep</rdfs:label>
     </owl:Class>
@@ -1606,8 +1617,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000068">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
         <obo:IAO_0000115>&quot;Repetitive movement of a body part.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shaking</rdfs:label>
     </owl:Class>
@@ -1618,8 +1629,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000069">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swaying</rdfs:label>
     </owl:Class>
@@ -1630,8 +1641,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000070">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tilting</rdfs:label>
     </owl:Class>
@@ -1643,8 +1654,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000071">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
         <obo:IAO_0000115>&quot;Behavior related to the movement facilitated by the generation of hole or tunnel dug into the ground.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">burrowing</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>burrowing behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1658,8 +1669,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000073">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of repeated grinding, tearing, and or crushing with teeth or jaws [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">chew</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">gnaw</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>mastication</oboInOwl:hasExactSynonym>
@@ -1673,8 +1684,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000074">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">yawning</rdfs:label>
     </owl:Class>
@@ -1686,8 +1697,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000075">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A very broad category including the partial or complete performance of adult functional behaviors in non-functional contexts, as well as interactive behaviors peculiar to immature animals [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">play</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">playing behavior</rdfs:label>
@@ -1700,8 +1711,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000076">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Undirected behavior involving exercise and coordination, and often associated with repetition and &apos;practice&apos; of adult behavior patterns in a non-functional context  [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>exercise</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>motor development playing behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">motor play</oboInOwl:hasExactSynonym>
@@ -1717,8 +1728,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000077">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000014"/>
         <obo:IAO_0000115>&quot;The behavioral interactions between organisms for the purpose of attracting sexual partners.&quot; [GOC:dph]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">courtship</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>courtship behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1733,8 +1744,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000078">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000010"/>
         <obo:IAO_0000115>&quot;Behavior related to the specific actions or reactions of an organism following mating.&quot; [GOC:bf]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000325</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>post mating behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">post-copulatory behavior</oboInOwl:hasExactSynonym>
@@ -1770,8 +1781,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of bringing an object or substance into the body by swallowing, surrounding or absorbing it [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>feeding behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007631</oboInOwl:xref>
@@ -1785,8 +1796,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000080">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving the body core lower, closer to the ground [NOB:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">sit down</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sitting down</rdfs:label>
@@ -1799,8 +1810,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000081">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving the body core higher, away from the ground [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">stand up</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">standing up</rdfs:label>
@@ -1812,8 +1823,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000082">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000002"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">writhe</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">writhing</rdfs:label>
@@ -1844,8 +1855,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to any biological process in an organism that recurs with a regularity of approximately 24 hours.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0048512</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian behavior</rdfs:label>
@@ -1858,8 +1869,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000085">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <obo:IAO_0000115>&quot;Emotional behavior related to a state of low mood  and aversion to activity.&quot; [wikipedia:Depression]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>depression related behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">depression behavior</rdfs:label>
@@ -1872,8 +1883,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000086">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <obo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel object, situation or environment.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">novelty response behavior</rdfs:label>
     </owl:Class>
@@ -1885,8 +1896,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000087">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000636"/>
         <obo:IAO_0000115>&quot;Behavior related to defence against predation or predators.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">antipredator behavior</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">antipredation behavior</rdfs:label>
@@ -1900,8 +1911,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000087"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000470"/>
         <obo:IAO_0000115>&quot;Behavior related to the preparation of the body to \&quot;fight\&quot; or \&quot;flee\&quot; from perceived attack, harm or threat.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>fight-or-flight response</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fight-or-flight-or-freeze response</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1916,8 +1927,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000120"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
         <obo:IAO_0000115>&quot;A physical aggression behavior involving attack on prey by a predator.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>predatory aggression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>predatory aggressive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -1932,8 +1943,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000090">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000087"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior directed at a predator that signifies hostility and predicts an increased probability of attack [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">threaten predator</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">threatening predator behavior</rdfs:label>
@@ -1946,8 +1957,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000091">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000018"/>
         <obo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness triggered by a specified triggering stimulus such as pain or the threat of danger.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:00:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>fear-related behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear-related behavior</rdfs:label>
@@ -1960,8 +1971,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000092">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000018"/>
         <obo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness triggered by an identifiable triggering stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:01:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>anxiety-related behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anxiety-related behavior</rdfs:label>
@@ -1974,8 +1985,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000093">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
         <obo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness in respect to an object.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:16:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear behavior towards objects</rdfs:label>
     </owl:Class>
@@ -1988,8 +1999,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000100"/>
         <obo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness in respect to a particular situation or environment.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:18:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear behavior towards situation/environment</rdfs:label>
     </owl:Class>
@@ -2001,8 +2012,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000095">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000091"/>
         <obo:IAO_0000115>&quot;An emotional behavior related to a feeling of uneasiness or nervousness in respect to a living thing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:18:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear behavior towards living things</rdfs:label>
     </owl:Class>
@@ -2015,8 +2026,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000094"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000246"/>
         <obo:IAO_0000115>&quot;A phobia characterised by fear of open spaces.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:18:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000756</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">agoraphobia behavior</rdfs:label>
@@ -2029,8 +2040,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000097">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000086"/>
         <obo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel environment.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:22:03Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response to novel environment</rdfs:label>
     </owl:Class>
@@ -2042,8 +2053,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000098">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000086"/>
         <obo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel obhject.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:23:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response to novel object</rdfs:label>
     </owl:Class>
@@ -2055,8 +2066,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000099">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000086"/>
         <obo:IAO_0000115>&quot;Behavior related to the exploration/investigation of a novel odor.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:24:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response to novel odor</rdfs:label>
     </owl:Class>
@@ -2067,8 +2078,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000100">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000097"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:28:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0035640</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exploration behavior</rdfs:label>
@@ -2081,8 +2092,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000101">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000056"/>
         <obo:IAO_0000115>&quot;Moving backwards.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:32:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">retropulsion</rdfs:label>
     </owl:Class>
@@ -2096,8 +2107,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000100"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000101"/>
         <obo:IAO_0000115>&quot;Moving backwards in response to a fear stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:36:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear-related retropulsion</rdfs:label>
     </owl:Class>
@@ -2109,8 +2120,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000103">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
         <obo:IAO_0000115>&quot;Behavioral response to the presidency of the stressor where it becomes necessary to attempt some means of coping with the stress.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:49:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coping behavior</rdfs:label>
     </owl:Class>
@@ -2122,8 +2133,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000104">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards humans.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:50:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards humans</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards humans</rdfs:label>
@@ -2136,8 +2147,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000105">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000740"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:51:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards animals</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards animals</rdfs:label>
@@ -2150,8 +2161,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000106">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000740"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action toward any type of object.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:51:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards objects</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards objects</rdfs:label>
@@ -2164,8 +2175,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000107">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards mice.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:51:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards mice</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards mice</rdfs:label>
@@ -2179,8 +2190,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000104"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000117"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards women.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:52:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards women</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards women</rdfs:label>
@@ -2194,8 +2205,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000104"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000118"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards men.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:52:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards men</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards men</rdfs:label>
@@ -2209,8 +2220,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000107"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000118"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards male mice.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:52:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards male mice</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards male mice</rdfs:label>
@@ -2224,8 +2235,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000107"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000117"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards female mice.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:53:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards female mice</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards female mice</rdfs:label>
@@ -2238,8 +2249,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000112">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000106"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action toward inanimate objects.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:53:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards inanimate objects</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards inanimate objects</rdfs:label>
@@ -2252,8 +2263,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000113">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000106"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action toward inanimate objects.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:53:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards animate objects</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards animate objects</rdfs:label>
@@ -2266,8 +2277,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000114">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000104"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards children.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:57:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards children</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards children</rdfs:label>
@@ -2280,8 +2291,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000115">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000107"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards pups.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T10:58:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards pups</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards pups</rdfs:label>
@@ -2294,8 +2305,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000116">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
         <obo:IAO_0000115>&quot;Gender related exhibition of a domineering, assault posture and/or hostile physical action.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:02:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>gender-related aggressive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gender-related aggressive behavior</rdfs:label>
@@ -2308,8 +2319,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000117">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards female animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:03:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior towards females</rdfs:label>
     </owl:Class>
@@ -2321,8 +2332,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
         <obo:IAO_0000115>&quot;Exhibiting a domineering, assault posture and/or hostile physical action towards male animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:04:03Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>aggressive behavior towards males</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>aggressive behavior towards males</rdfs:label>
@@ -2335,8 +2346,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000119">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;A behavior that occur quickly without control, planning, or consideration of the consequences of that behavior.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:08:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">impulsive behavior</rdfs:label>
     </owl:Class>
@@ -2348,8 +2359,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000120">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000741"/>
         <obo:IAO_0000115>&quot;An aggressive behavior that aims to inflicting damage on another entity using physical means.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:14:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>physical aggression behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>violent behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -2363,8 +2374,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000121">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:42:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">agonism</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">agonistic behavior</rdfs:label>
@@ -2377,8 +2388,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000122">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any behavior that tends to prevent further or future attack, often by signalling a willingness to yield or surrender [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:43:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>submissive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">submissive behavior</rdfs:label>
@@ -2391,8 +2402,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000123">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000122"/>
         <obo:IAO_0000115>&quot;A behavior associated with the tendency of an organism towards being passive and willing to yield to male animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:43:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>submissive behavior towards males</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>submissive behavior towards males</rdfs:label>
@@ -2405,8 +2416,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000124">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000122"/>
         <obo:IAO_0000115>&quot;A behavior associated with the tendency of an organism towards being passive and willing to yield to female animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:44:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>submissive behavior towards females</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>submissive behavior towards females</rdfs:label>
@@ -2419,8 +2430,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000125">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000123"/>
         <obo:IAO_0000115>&quot;A behavior associated with the tendency of an organism towards being passive and willing to yield towards male mice.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:44:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>submissive behavior towards male mice</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>submissive behavior towards male mice</rdfs:label>
@@ -2432,8 +2443,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000126">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000122"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:47:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">subordination behavior</rdfs:label>
     </owl:Class>
@@ -2445,8 +2456,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000127">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior by which an animal removes itself spatially from an agonistic encounter in which it is not the winner [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T11:49:03Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">retreat</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>retreat behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -2460,8 +2471,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000128">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
         <obo:IAO_0000115>&quot;Behavior characterized by a quick excitability to annoyance, impatience, or anger.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:16:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">irritability behavior</rdfs:label>
     </owl:Class>
@@ -2473,8 +2484,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000129">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <obo:IAO_0000115>&quot;Emotional behavior related to excitement or restlessness.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:22:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">agitation behavior</rdfs:label>
     </owl:Class>
@@ -2492,8 +2503,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A behavior associated with the intake of liquid.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:40:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid consumption</rdfs:label>
     </owl:Class>
@@ -2522,8 +2533,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A drinking behavior associated with the intake of alcohol.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:40:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol consumption</rdfs:label>
     </owl:Class>
@@ -2552,8 +2563,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A drinking behavior associated with the intake of water.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:41:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0045187</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">water consumption</rdfs:label>
@@ -2591,8 +2602,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000540"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:41:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid preference/aversion</rdfs:label>
     </owl:Class>
@@ -2621,8 +2632,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A feeding behavior associated with the intake of food.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:42:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food consumption</rdfs:label>
     </owl:Class>
@@ -2649,8 +2660,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:43:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food preference/aversion</rdfs:label>
     </owl:Class>
@@ -2679,8 +2690,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A feeding behavior associated with the intake of saccharin.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:50:41Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saccharin consumption</rdfs:label>
     </owl:Class>
@@ -2718,8 +2729,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000133"/>
         <obo:IAO_0000115>&quot;Predilection to ingest a liquid over other substances.&quot; [NBOC:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:55:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid preference</rdfs:label>
     </owl:Class>
@@ -2757,8 +2768,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000133"/>
         <obo:IAO_0000115>&quot;Purposeful avoidance of a liquid due to dislike.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:55:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liquid aversion</rdfs:label>
     </owl:Class>
@@ -2786,8 +2797,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000138"/>
         <obo:IAO_0000115>&quot;Purposeful avoidance of liquid alcohol due to dislike.&quot; [NBO:GVG] [NBO:LKSR]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:55:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol aversion</rdfs:label>
     </owl:Class>
@@ -2815,8 +2826,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000137"/>
         <obo:IAO_0000115>&quot;Predilection to ingest alcohol over other substances.&quot; [NBOC:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:56:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol preference</rdfs:label>
     </owl:Class>
@@ -2843,8 +2854,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000135"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:58:43Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food preference</rdfs:label>
     </owl:Class>
@@ -2871,8 +2882,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000135"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:59:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food aversion</rdfs:label>
     </owl:Class>
@@ -2899,8 +2910,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000141"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T12:59:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saccharin preference</rdfs:label>
     </owl:Class>
@@ -2927,8 +2938,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000756"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:16:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating frequency</rdfs:label>
     </owl:Class>
@@ -2955,8 +2966,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000756"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:17:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>mate choice</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating preference</rdfs:label>
@@ -2968,8 +2979,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000146">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000014"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:17:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating receptivity</rdfs:label>
     </owl:Class>
@@ -2980,8 +2991,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000147">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000014"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:21:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mate attraction behavior</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual display behavior</rdfs:label>
@@ -2993,8 +3004,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000148">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:24:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social investigation</rdfs:label>
     </owl:Class>
@@ -3005,8 +3016,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000149">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:25:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reclusive behavior</rdfs:label>
     </owl:Class>
@@ -3018,8 +3029,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000150">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
         <obo:IAO_0000115>&quot;Behavior of a mother towards her offspring.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:32:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042711</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal behavior</rdfs:label>
@@ -3032,8 +3043,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000151">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
         <obo:IAO_0000115>&quot;Behavior of a father towards his offspring.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:32:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042712</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paternal behavior</rdfs:label>
@@ -3046,8 +3057,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000152">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000150"/>
         <obo:IAO_0000115>&quot;Maternal behavior related to the brining up her offspring.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:33:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal nurturing behavior</rdfs:label>
     </owl:Class>
@@ -3059,8 +3070,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000153">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000151"/>
         <obo:IAO_0000115>&quot;Paternal behavior related to the brining up his offspring.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:33:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paternal nurturing behavior</rdfs:label>
     </owl:Class>
@@ -3071,8 +3082,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000154">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000152"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:35:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal crouching</rdfs:label>
     </owl:Class>
@@ -3084,8 +3095,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000155">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000048"/>
         <obo:IAO_0000115>&quot;Behavior related to the parent&apos;s tendency to collect stray offspring and return them to a defined location.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:42:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">retrieval</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">offspring retrieval</rdfs:label>
@@ -3097,8 +3108,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000156">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:53:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nesting behavior</rdfs:label>
     </owl:Class>
@@ -3109,8 +3120,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000157">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000156"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:54:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nest building behavior</rdfs:label>
     </owl:Class>
@@ -3121,8 +3132,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000158">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T02:59:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep pattern</rdfs:label>
     </owl:Class>
@@ -3153,8 +3164,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0042747"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:00:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>REM sleep</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>paradoxical sleep</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -3183,8 +3194,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:09:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep duration</rdfs:label>
     </owl:Class>
@@ -3205,8 +3216,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to all sleep stages in the circadian sleep/wake cycle other than REM sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:12:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>NREM sleep behavior</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>These stages are characterized by a slowing of brain waves and other physiological functions.</rdfs:comment>
@@ -3236,8 +3247,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000754"/>
         <obo:IAO_0000115>&quot;Duration of REM sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:15:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM duration</rdfs:label>
     </owl:Class>
@@ -3264,8 +3275,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000754"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:15:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM frequency</rdfs:label>
     </owl:Class>
@@ -3294,8 +3305,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000160"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000753"/>
         <obo:IAO_0000115>&quot;Duration of REM sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:16:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NREM duration</rdfs:label>
     </owl:Class>
@@ -3322,8 +3333,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000753"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:16:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NREM frequency</rdfs:label>
     </owl:Class>
@@ -3335,8 +3346,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000166">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
         <obo:IAO_0000115>&quot;Endogenously driven roughly 24-hour cycle in biochemical, physiological, or behavioral processes.&quot; [GOC:bf]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:22:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007623</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian rhythm</rdfs:label>
@@ -3348,8 +3359,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000167">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000166"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:23:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian period</rdfs:label>
     </owl:Class>
@@ -3360,8 +3371,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000168">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000166"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:23:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian persistence</rdfs:label>
     </owl:Class>
@@ -3372,8 +3383,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000169">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000166"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-03-31T03:24:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian phase</rdfs:label>
     </owl:Class>
@@ -3385,8 +3396,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000170">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000006"/>
         <obo:IAO_0000115>&quot;Behavior related with the ability of an organism&apos;s ability to store, retain, and recall information and experiences.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T01:49:03Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>memory behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007613</oboInOwl:xref>
@@ -3401,8 +3412,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000022"/>
         <obo:IAO_0000115>&quot;Learning by associating a stimulus (the cause) with a particular outcome (the effect).&quot; [Wikipedia:Learning#Associative_learning]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T01:49:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>conditional learning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0008306</oboInOwl:xref>
@@ -3417,8 +3428,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000172">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000323"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000641"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T01:54:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0008355</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory learning behavior</rdfs:label>
@@ -3431,8 +3442,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000173">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000314"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000641"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T01:54:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0008542</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual learning behavior</rdfs:label>
@@ -3461,8 +3472,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T01:56:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motor learning</rdfs:label>
     </owl:Class>
@@ -3473,8 +3484,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000175">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T01:57:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial learning</rdfs:label>
     </owl:Class>
@@ -3503,8 +3514,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A behavioral process whose outcome is a relatively long-lasting adaptive behavioral change whereby an organism modifies innate vocalizations to imitate or create new sounds.&quot; [GO:0042297]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T01:58:41Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042297</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vocal learning</rdfs:label>
@@ -3517,8 +3528,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000177">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000022"/>
         <obo:IAO_0000115>&quot;A decrease in a behavioral response to a repeated stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T03:18:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>nonassociative learning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>unconditional response</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -3533,8 +3544,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000178">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000177"/>
         <obo:IAO_0000115>&quot;Gradual decrease in behavioral responses with repeated encounters of a particular stimulus, which proves of no consequence.&quot; [wikipedia:Habituation]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T03:19:06Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0046959</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">habituation</rdfs:label>
@@ -3547,8 +3558,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000179">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000177"/>
         <obo:IAO_0000115>&quot;An increase in behavioral responses following repeated applications of a particular stimulus.&quot; [wikipedia:Sensitization]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T03:54:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensitization</rdfs:label>
     </owl:Class>
@@ -3560,8 +3571,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000180">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
         <obo:IAO_0000115>&quot;A type of memory that allows the recall of something from several seconds to as long as a minute.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T03:59:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007614</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short-term memory</rdfs:label>
@@ -3574,8 +3585,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000181">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
         <obo:IAO_0000115>&quot;This type of memory, lasting hours to months, critically depends on a transfer of the information from short term memory using repeated rehearsal.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T03:59:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007616</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long-term memory</rdfs:label>
@@ -3588,8 +3599,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000182">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
         <obo:IAO_0000115>&quot;Report great detail about a complex stimulus immediately following its presentation. This ability forms within a few tens of milliseconds and decays again rapidly within a few hundred milliseconds.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T03:59:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensory memory</rdfs:label>
     </owl:Class>
@@ -3601,8 +3612,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000183">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
         <obo:IAO_0000115>&quot;A memory that last for months to lifetime.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T04:00:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long-lasting memory</rdfs:label>
     </owl:Class>
@@ -3614,8 +3625,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000184">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
         <obo:IAO_0000115>&quot;A type of memory that allows the recall of something from minutes to several hours.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-01T04:01:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0072375</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medium term memory</rdfs:label>
@@ -3628,8 +3639,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000185">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000181"/>
         <obo:IAO_0000115>&quot;Ability to become conscious of, or declare, facts and experiences.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T07:38:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>explicit memory</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Encoded by the hippocampus, entorhinal cortex, and perirhinal cortex but store possibly in the medial temporal lobe.</rdfs:comment>
@@ -3643,8 +3654,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000186">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
         <obo:IAO_0000115>&quot;Ability to consciously recall knowledge of facts that are independent of a specific time and place.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T07:40:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Medial temporal lobe, diencephalon.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">semantic memory</rdfs:label>
@@ -3657,8 +3668,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000187">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
         <obo:IAO_0000115>&quot;Ability to explicitly recall information about a specific event that has occurred at a specific time and place.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T07:41:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Medial temporal lobe, diencephalon.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">episodic memory</rdfs:label>
@@ -3671,8 +3682,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000188">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000181"/>
         <obo:IAO_0000115>&quot;Non-declarative memory type of memory, which does not need to involve conscious awareness in the act of recollection.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T07:42:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000189</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>implicit memory</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>procedural memory</oboInOwl:hasExactSynonym>
@@ -3688,8 +3699,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000190">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000188"/>
         <obo:IAO_0000115>&quot;Consolidating a specific motor task into memory through repetition.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T07:54:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>muscle memory</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Depends on the cerebellum and basal ganglia.</rdfs:comment>
@@ -3703,8 +3714,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000191">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000181"/>
         <obo:IAO_0000115>&quot;A type of memory associated with emotional experiences.&quot; [wikipedia:http\://www.scholarpedia.org/article/Emotional_memory]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T07:59:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emotional memory</rdfs:label>
     </owl:Class>
@@ -3716,8 +3727,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000192">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
         <obo:IAO_0000115>&quot;Remembering to perform an intended action.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:16:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prospective memory</rdfs:label>
     </owl:Class>
@@ -3729,8 +3740,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000193">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000192"/>
         <obo:IAO_0000115>&quot;Remembering to perform an intended action in respect to a particular event.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:19:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">event-based prospective memory</rdfs:label>
     </owl:Class>
@@ -3742,8 +3753,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000194">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000192"/>
         <obo:IAO_0000115>&quot;Remembering to perform an intended action in respect to a particular time reference.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:19:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">time-based prospective memory</rdfs:label>
     </owl:Class>
@@ -3755,8 +3766,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000195">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000187"/>
         <obo:IAO_0000115>&quot;A type of memory for particular events within one&apos;s own life.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:27:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">autobiographical memory</rdfs:label>
     </owl:Class>
@@ -3768,8 +3779,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000196">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
         <obo:IAO_0000115>&quot;Ability to store and retrieve previously experienced visual sensations and perceptions when the stimuli that originally evoked them are no longer present.&quot; [wikipedia:Visual_memory]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:33:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual memory</rdfs:label>
     </owl:Class>
@@ -3780,8 +3791,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000197">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000182"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:37:43Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">iconic memory</rdfs:label>
     </owl:Class>
@@ -3793,8 +3804,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000198">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000182"/>
         <obo:IAO_0000115>&quot;The ability to recall images, sounds, or objects in memory with extreme precision and in abundant volume.&quot; [wikipedia:Eidetic_memory]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:39:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>photographic memory</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eidetic memory</rdfs:label>
@@ -3807,8 +3818,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000199">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
         <obo:IAO_0000115>&quot;Ability to orient oneself in space, to recognize and follow an itinerary, or to recognize familiar places.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:42:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">topographic memory</rdfs:label>
     </owl:Class>
@@ -3820,8 +3831,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000200">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000307"/>
         <obo:IAO_0000115>&quot;An implicit memory effect in which exposure to a stimulus influences response to a later stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:50:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">priming</rdfs:label>
     </owl:Class>
@@ -3832,8 +3843,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000201">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:55:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>repetition</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">direct priming</rdfs:label>
@@ -3846,8 +3857,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000202">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
         <obo:IAO_0000115>&quot;A type of priming where the prime and the target are from the same semantic category and share features.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:56:35Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">semantic priming</rdfs:label>
     </owl:Class>
@@ -3859,8 +3870,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000203">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
         <obo:IAO_0000115>&quot;A type of priming where the target is a word that has a high probability of appearing with the prime, and is \&quot;associated\&quot; with it but not necessarily related in semantic features.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:57:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">associative priming</rdfs:label>
     </owl:Class>
@@ -3871,8 +3882,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000204">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:58:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">response priming</rdfs:label>
     </owl:Class>
@@ -3884,8 +3895,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000205">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
         <obo:IAO_0000115>&quot;A type of priming based on the meaning of a stimulus and is enhanced by semantic task.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T08:59:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conceptual priming</rdfs:label>
     </owl:Class>
@@ -3897,8 +3908,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000206">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000200"/>
         <obo:IAO_0000115>&quot;A type priming based on the form of the stimulus and is enhanced by the match between the early and later stimuli.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T09:00:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perceptual priming</rdfs:label>
     </owl:Class>
@@ -3910,8 +3921,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000207">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000178"/>
         <obo:IAO_0000115>&quot;Change in the responsiveness of a sensory system when confronted with a constant stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-02T09:07:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensory adaptation</rdfs:label>
     </owl:Class>
@@ -3923,8 +3934,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000208">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
         <obo:IAO_0000115>&quot;A form of associative learning that requires an unconditional reflex, where an unconditional stimulus (US)brings about an automatic, unlearned (unconditional) response (UR). If a neutral stimulus (NS) tends to precede it, an association is made and the conditional response (CR) becomes transferred onto the (previously neutral) conditional strimulus (CS); a conditional reflex has been learned.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T08:57:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Pavlovian conditioning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>respondent conditioning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -3955,8 +3966,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A type of associative learning that allows organisms to acquire affective responses, such as fear, in situations where a particular context or stimulus is predictably elicits fear via an aversive context.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T08:58:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fear conditioning</rdfs:label>
     </owl:Class>
@@ -3967,8 +3978,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000210">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T09:01:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">avoidance learning behavior</rdfs:label>
     </owl:Class>
@@ -3979,8 +3990,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000211">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000208"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T09:04:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Garcia conditioning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0001661</oboInOwl:xref>
@@ -3994,8 +4005,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000212">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
         <obo:IAO_0000115>&quot;Operant conditioning is the use of a behavior&apos;s antecedent and/or its consequence to influence the occurrence and form of behavior.&quot; [wikipedia:Operant_conditioning]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T09:05:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>instrumental conditioning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>instrumental learning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -4010,8 +4021,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000213">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T09:08:06Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">imprinting behavior</rdfs:label>
     </owl:Class>
@@ -4022,8 +4033,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000214">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T09:11:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">latent learning behavior</rdfs:label>
     </owl:Class>
@@ -4034,8 +4045,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000215">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000220"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T09:11:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>modeling</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>vicarious learning</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -4065,8 +4076,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000745"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-03T09:11:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">language learning behavior</rdfs:label>
     </owl:Class>
@@ -4078,8 +4089,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000217">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000210"/>
         <obo:IAO_0000115>&quot;Avoidance learning when the action occurs.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:22:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">active avoidance learning behavior</rdfs:label>
     </owl:Class>
@@ -4091,8 +4102,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000218">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000210"/>
         <obo:IAO_0000115>&quot;Avoidance learning when no action occurs.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:22:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">passive avoidance learning behavior</rdfs:label>
     </owl:Class>
@@ -4104,8 +4115,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000219">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000210"/>
         <obo:IAO_0000115>&quot;Avoid a situation completely.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:25:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">escape learning behavior</rdfs:label>
     </owl:Class>
@@ -4117,8 +4128,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000220">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
         <obo:IAO_0000115>&quot;The sociological process of training individuals in a society to act or respond in a manner generally approved by the society in general and peer groups within society.&quot; [wikipedia:Social_conditioning]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:34:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social learning</rdfs:label>
     </owl:Class>
@@ -4147,8 +4158,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000778"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:36:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conditioned emotional response</rdfs:label>
     </owl:Class>
@@ -4159,8 +4170,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000222">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:40:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conditioned place preference behavior</rdfs:label>
     </owl:Class>
@@ -4171,8 +4182,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000223">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:42:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">contextual conditioning behavior</rdfs:label>
     </owl:Class>
@@ -4183,8 +4194,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000224">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:43:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cued conditioning behavior</rdfs:label>
     </owl:Class>
@@ -4196,8 +4207,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000225">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
         <obo:IAO_0000115>&quot;Perception of objects remains the same despite changes in their image on the retina.&quot; [:http\://science.jrank.org/pages/5094/Perception.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:47:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perceptual constancy behavior</rdfs:label>
     </owl:Class>
@@ -4208,8 +4219,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000226">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:48:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spinal conditioning</rdfs:label>
     </owl:Class>
@@ -4237,8 +4248,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000749"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:55:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye blink conditioning behavior</rdfs:label>
     </owl:Class>
@@ -4266,8 +4277,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000747"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T03:57:01Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jaw movement conditioning behavior</rdfs:label>
     </owl:Class>
@@ -4295,8 +4306,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000656"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the awareness of body balance and movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T06:34:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pathological vestibular behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibular behavior phenotype</rdfs:label>
@@ -4308,8 +4319,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000230">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T07:49:51Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pleasure behavior</rdfs:label>
     </owl:Class>
@@ -4320,8 +4331,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000231">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T07:50:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">excitement behavior</rdfs:label>
     </owl:Class>
@@ -4332,8 +4343,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000232">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T07:50:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">distress behavior</rdfs:label>
     </owl:Class>
@@ -4345,8 +4356,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000233">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;Behavior related to the tendency of an organism to maintain internal equilibrium.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:29:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000050</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>behavioral homeostasis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>maintenance behaviour</oboInOwl:hasExactSynonym>
@@ -4363,8 +4374,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0009414"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
         <obo:IAO_0000115>&quot;Behavior related to the deprivation of water.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:29:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thirst motivation behavior</rdfs:label>
     </owl:Class>
@@ -4376,8 +4387,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000235">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
         <obo:IAO_0000115>&quot;Behavior related to the deprivation of food.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:30:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>appetite related behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hunger motivation behavior</rdfs:label>
@@ -4390,8 +4401,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000236">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
         <obo:IAO_0000115>&quot;Behavior related to the drive of an organism to engage in sexual activity.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:30:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual motivation behavior</rdfs:label>
     </owl:Class>
@@ -4403,8 +4414,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000237">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000235"/>
         <obo:IAO_0000115>&quot;Any process which modulates the physical craving for food.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:33:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0032098</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hunger regulation</rdfs:label>
@@ -4417,8 +4428,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000238">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000237"/>
         <obo:IAO_0000115>&quot;Any process which modulates the physical craving for food over short term food deprivation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:33:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term hunger regulation</rdfs:label>
     </owl:Class>
@@ -4430,8 +4441,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000239">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000237"/>
         <obo:IAO_0000115>&quot;Any process which modulates the physical craving for food over long term food deprivation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:33:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term hunger regulation</rdfs:label>
     </owl:Class>
@@ -4442,8 +4453,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000240">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:35:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anorexia nervosa</rdfs:label>
     </owl:Class>
@@ -4454,8 +4465,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000241">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:36:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bulimia nervosa</rdfs:label>
     </owl:Class>
@@ -4466,8 +4477,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000242">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:36:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obesity</rdfs:label>
     </owl:Class>
@@ -4478,8 +4489,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000243">
         <obo:IAO_0000115>&quot;An observable characteristic of the behavior of an organism.&quot; [NBO:RH]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:51:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000708</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral phenotype</rdfs:label>
@@ -4491,8 +4502,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000244">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:51:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hysteria</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>pathological anxiety disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -4506,8 +4517,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000245">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
         <obo:IAO_0000115>&quot;A pathological anxiety characterized by long-lasting anxiety that is not focused on any one object or situation.&quot; [wikipedia:Generalized_anxiety_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:52:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>GAD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">generalized anxiety</rdfs:label>
@@ -4520,8 +4531,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000246">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
         <obo:IAO_0000115>&quot;A pathological anxiety characterized by fear or anxiety triggered by a specific stimulus or situation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:52:18Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>phobic disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phobia</rdfs:label>
@@ -4534,8 +4545,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000247">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
         <obo:IAO_0000115>&quot;A pathological anxiety characterized by brief attacks of intense terror and apprehension, often marked by trembling, shaking, confusion, dizziness, nausea, difficulty breathing.&quot; [wikipedia:Panic_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:52:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">panic</rdfs:label>
     </owl:Class>
@@ -4547,8 +4558,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000248">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
         <obo:IAO_0000115>&quot;A pathological anxiety primarily characterized by repetitive obsessions (distressing, persistent, and intrusive thoughts or images) and compulsions (urges to perform specific acts or rituals).&quot; [wikipedia:Obsessive%E2%80%93compulsive_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:52:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>OCD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000722</oboInOwl:xref>
@@ -4562,8 +4573,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000249">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
         <obo:IAO_0000115>&quot;A pathological behavior characterized by one or more symptoms of a physical dysfunction but for which there is no identifiable organic cause.&quot; [wikipedia:Somatoform_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:53:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pathological somatoform behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somatoform behavior phenotype</rdfs:label>
@@ -4576,8 +4587,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000250">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000249"/>
         <obo:IAO_0000115>&quot;A somatoform disorder characterised by a physical dysfunction (blindness, deafness, paralysis, numbness, etc. ) that has no underlying organic basis.&quot; [wikipedia:Conversion_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:53:18Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hysteria</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conversion disorder</rdfs:label>
@@ -4590,8 +4601,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000251">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000249"/>
         <obo:IAO_0000115>&quot;A somatoform disorder characterised by a continuing belief that one has one or more serious illnesses although no medical evidence supports the belief.&quot; [wikipedia:Hypochondriasis]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:53:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>health anxiety</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>health phobia</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>hypochondria</oboInOwl:hasExactSynonym>
@@ -4605,8 +4616,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000252">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:54:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative disorders</rdfs:label>
     </owl:Class>
@@ -4617,8 +4628,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000253">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000252"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:54:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative amnesia</rdfs:label>
     </owl:Class>
@@ -4629,8 +4640,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000254">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000252"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:54:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative fugue</rdfs:label>
     </owl:Class>
@@ -4641,8 +4652,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000255">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000252"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:54:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dissociative identity disorder</rdfs:label>
     </owl:Class>
@@ -4653,8 +4664,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000256">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:55:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mood disorder</rdfs:label>
     </owl:Class>
@@ -4665,8 +4676,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000257">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:55:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>MDD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>clinical depression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>major depression</oboInOwl:hasExactSynonym>
@@ -4682,8 +4693,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000258">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000256"/>
         <obo:IAO_0000115>&quot;A mood disorder formerly characterised by alternating periods of mania and depression (and in some cases rapid cycling, mixed states, and psychotic symptoms).&quot; [wikipedia:Bipolar_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:55:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>BD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>bipolar affective disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>manic depression</oboInOwl:hasExactSynonym>
@@ -4698,8 +4709,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000259">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:56:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000709</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">psychotic disorder</rdfs:label>
@@ -4711,8 +4722,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000260">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:56:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paranoid schizophrenia</rdfs:label>
     </owl:Class>
@@ -4723,8 +4734,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000261">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:57:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catatonic schizophrenia</rdfs:label>
     </owl:Class>
@@ -4735,8 +4746,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000262">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:57:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disorganized (hebephrenic) schizophrenia</rdfs:label>
     </owl:Class>
@@ -4747,8 +4758,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000263">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:57:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">undifferentiated schizophrenia</rdfs:label>
     </owl:Class>
@@ -4759,8 +4770,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000264">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000259"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:57:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">residual schizophrenia</rdfs:label>
     </owl:Class>
@@ -4771,8 +4782,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000265">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T08:59:01Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000751</oboInOwl:xref>
         <rdfs:comment>(http://www.cliffsnotes.com/study_guide/Classifying-Psychological-Disorders.topicArticleId-25438,articleId-25396.html).</rdfs:comment>
@@ -4803,8 +4814,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000001"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to cognitive processes.&quot; [NBO:RH]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:01:18Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cognitive behavior phenotype</rdfs:label>
     </owl:Class>
@@ -4815,8 +4826,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000267">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:01:41Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delirium</rdfs:label>
     </owl:Class>
@@ -4827,8 +4838,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000268">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:01:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000726</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dementia</rdfs:label>
@@ -4840,8 +4851,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000269">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:02:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amnestic disorder</rdfs:label>
     </owl:Class>
@@ -4869,8 +4880,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior associated with the intake of food or liquids.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:02:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feeding behavior phenotype</rdfs:label>
     </owl:Class>
@@ -4882,8 +4893,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000271">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behaviors that are described for or done by groups of animals, not individual animals [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:05:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">group actions</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">group behavior</rdfs:label>
@@ -4895,8 +4906,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000272">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:05:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social facilitation</rdfs:label>
     </owl:Class>
@@ -4907,8 +4918,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000273">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:05:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>social loafing</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social interference</rdfs:label>
@@ -4920,8 +4931,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000274">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:06:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">group polarization</rdfs:label>
     </owl:Class>
@@ -4932,8 +4943,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000275">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000271"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:06:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">groupthink</rdfs:label>
     </owl:Class>
@@ -4962,8 +4973,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A behavioral interaction between organisms in which one organism exhibits aggression using vocal or verbal means.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:07:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>verbal aggression behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vocal aggression behavior</rdfs:label>
@@ -4975,8 +4986,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000277">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:11:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>&lt;new synonym&gt;</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>discrimination</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>prejudice</oboInOwl:hasExactSynonym>
@@ -4990,8 +5001,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000278">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000277"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:12:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>sexism</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gender specific discriminatory behavior</rdfs:label>
@@ -5004,8 +5015,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000279">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000277"/>
         <obo:IAO_0000115>&quot;A discriminatory behavior that is related to age.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:12:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>ageism</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">age specific discriminatory behavior</rdfs:label>
@@ -5017,8 +5028,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000280">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:16:35Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">attraction-related behavior</rdfs:label>
     </owl:Class>
@@ -5030,8 +5041,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000281">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
         <obo:IAO_0000115>&quot;Behavior related to having a generally positive attitude toward another person.&quot; [MBP:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:16:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">affiliation</rdfs:label>
     </owl:Class>
@@ -5043,8 +5054,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000282">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000280"/>
         <obo:IAO_0000115>&quot;Wanting to be with another person.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:17:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">liking</rdfs:label>
     </owl:Class>
@@ -5055,8 +5066,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000283">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000282"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:17:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">friendship</rdfs:label>
     </owl:Class>
@@ -5067,8 +5078,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000284">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000282"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:18:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">love</rdfs:label>
     </owl:Class>
@@ -5080,8 +5091,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000285">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000286"/>
         <obo:IAO_0000115>&quot;A helping behavior (without expectation of extrinsic rewards and sometimes involving personal risk or sacrifice) that benefits individuals or society.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:19:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">altruism behavior</rdfs:label>
     </owl:Class>
@@ -5093,8 +5104,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000286">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <obo:IAO_0000115>&quot;Prosocial behavior is caring about the welfare and rights of others, feeling concern and empathy for them, and acting in ways that benefit others.&quot; [wikipedia:Prosocial_behavior]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:22:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">prosocial behavior</rdfs:label>
     </owl:Class>
@@ -5106,8 +5117,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000287">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000286"/>
         <obo:IAO_0000115>&quot;Helping behavior refers to voluntary actions intended to help the others, with reward regarded or disregarded.&quot; [wikipedia:Helping_behavior]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:23:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helping behavior</rdfs:label>
     </owl:Class>
@@ -5119,8 +5130,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000288">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000286"/>
         <obo:IAO_0000115>&quot;Reciprocal altruism is the idea that the incentive for an individual to help in the present is based on the expectation of the potential receipt in the future.&quot; [wikipedia:Helping_behavior]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:25:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reciprocal altruism</rdfs:label>
     </owl:Class>
@@ -5131,8 +5142,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000289">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:26:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social influence related behavior</rdfs:label>
     </owl:Class>
@@ -5143,8 +5154,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000290">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000289"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:27:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">conformity</rdfs:label>
     </owl:Class>
@@ -5155,8 +5166,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000291">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000289"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:27:43Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obedience to authority</rdfs:label>
     </owl:Class>
@@ -5167,8 +5178,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000292">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000289"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:27:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bystander intervention</rdfs:label>
     </owl:Class>
@@ -5180,8 +5191,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000293">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000607"/>
         <obo:IAO_0000115>&quot;Behavior related to one or more capacities of the mind.&quot; [wikipedia:Intelligence]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:30:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from intelligence</rdfs:label>
     </owl:Class>
@@ -5193,8 +5204,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000294">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
         <obo:IAO_0000115>&quot;Behavior stemming from the ability to identify, assess, and control the emotions of oneself, of others, and of groups.&quot; [wikipedia:Emotional_intelligence]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:30:47Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from emotional intelligence</rdfs:label>
     </owl:Class>
@@ -5205,8 +5216,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000295">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000238"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-18T10:37:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">satiation</rdfs:label>
     </owl:Class>
@@ -5218,8 +5229,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000296">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Behavior that facilitates the restoration of normal interactions between parties that recently engaged in a conflict.[NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T09:50:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">reconciliation</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">reconciliation behavior</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -5233,8 +5244,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000297">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
         <obo:IAO_0000115>&quot;Behavior associated with problem finding and problem shaping.&quot; [wikipedia:Problem_solving]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:31:35Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from problem solving</rdfs:label>
     </owl:Class>
@@ -5247,8 +5258,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
         <obo:IAO_0000115>&quot;Behavior stemming from intelligence associated with the capacity of conveying information. (Example: behavior adaptation in chimpanzees in order to communicate with humans.)&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:31:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from communication intelligence</rdfs:label>
     </owl:Class>
@@ -5259,8 +5270,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000299">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000044"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:36:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alloparental behavior</rdfs:label>
     </owl:Class>
@@ -5272,8 +5283,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000300">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
         <obo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by male animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:39:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>male aggressive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0001966</oboInOwl:xref>
@@ -5287,8 +5298,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000301">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000116"/>
         <obo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by female animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:39:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>female aggressive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female aggressive behavior</rdfs:label>
@@ -5303,8 +5314,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000150"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000301"/>
         <obo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by a mother or attending female.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:39:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>maternal aggression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0002125</oboInOwl:xref>
@@ -5320,8 +5331,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000151"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000300"/>
         <obo:IAO_0000115>&quot;A domineering, assault posture and/or hostile physical action towards animals exhibited by a father or attending male.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:40:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>paternal aggression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">paternal aggressive behavior</rdfs:label>
@@ -5334,8 +5345,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000304">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
         <obo:IAO_0000115>&quot;Behavior related with the gradual loss of information and experiences stored in the memory of an organism.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:49:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>forgetting</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory loss behavior</rdfs:label>
@@ -5347,8 +5358,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000305">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:49:41Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory encoding behavior</rdfs:label>
     </owl:Class>
@@ -5360,8 +5371,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000306">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
         <obo:IAO_0000115>&quot;Behavior related with the ability of an organism&apos;s ability to store information and experiences.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:53:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>memory storage behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory storage behavior</rdfs:label>
@@ -5374,8 +5385,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000307">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000170"/>
         <obo:IAO_0000115>&quot;Behavior related with the ability of an organism&apos;s ability to recall information and experiences.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T09:55:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>memory retrieval behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory retrieval behavior</rdfs:label>
@@ -5388,8 +5399,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000308">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000607"/>
         <obo:IAO_0000115>&quot;Cognitive perception of a sensation by any of the five senses -- vision, touch, smell, taste, and hearing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-04T10:00:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000454</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>behavior involving perception</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>perception behavior</oboInOwl:hasExactSynonym>
@@ -5405,8 +5416,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000309">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000246"/>
         <obo:IAO_0000115>&quot;A phobia characterised by fear of social or performance situations in which embarrassment may occur.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T09:35:47Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social phobia</rdfs:label>
     </owl:Class>
@@ -5418,8 +5429,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000310">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000246"/>
         <obo:IAO_0000115>&quot;A phobia characterised by fear of high places.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T09:36:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acrophobia</rdfs:label>
     </owl:Class>
@@ -5431,8 +5442,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000311">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
         <obo:IAO_0000115>&quot;Behavior related to the actions of an organism in relation to sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T09:46:01Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>sleep motivation behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep motivation behavior</rdfs:label>
@@ -5445,8 +5456,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000312">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000311"/>
         <obo:IAO_0000115>&quot;Any process that modulates the frequency, rate or extent of sleep.&quot; [GOC:jl]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T09:46:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regulation of sleep</rdfs:label>
     </owl:Class>
@@ -5457,8 +5468,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000313">
         <obo:IAO_0000115>&quot;The action, reaction, or performance of an organism in response to external or internal stimuli.&quot; [GO:GO\:0007610]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T09:53:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000000</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>behavior</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>behaviour</oboInOwl:hasExactSynonym>
@@ -5491,8 +5502,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to the actions or reactions of an organism in response to a visual stimulus.&quot; [GO:0007632]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:36:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>behavioral response to visual stimulus</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>behavioural response to visual stimulus</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>visual behaviour</oboInOwl:hasExactSynonym>
@@ -5507,8 +5518,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000315">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000314"/>
         <obo:IAO_0000115>&quot;Behavior related to the actions or reactions of an organism pertaining to movement of the eyes and of objects in the visual field, as in nystagmus.&quot; [GO:0007634]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:37:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007634</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optokinetic behavior</rdfs:label>
@@ -5544,8 +5555,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to the actions or reactions of an organism in response to a sound.&quot; [GO:0031223]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:38:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hearing behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0031223</oboInOwl:xref>
@@ -5559,8 +5570,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000317">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000327"/>
         <obo:IAO_0000115>&quot;Behavior related to the awareness of body balance and movement.&quot; [MBP:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:40:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>proprioception</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibular behavior</rdfs:label>
@@ -5572,8 +5583,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000318">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:44:05Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">balance</rdfs:label>
     </owl:Class>
@@ -5584,8 +5595,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000319">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:44:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body rotation sensation behavior</rdfs:label>
     </owl:Class>
@@ -5602,8 +5613,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050957"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:44:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gravitation sensation behavior</rdfs:label>
     </owl:Class>
@@ -5614,8 +5625,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000321">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:44:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">movement sensation behavior</rdfs:label>
     </owl:Class>
@@ -5644,8 +5655,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior as a result of the sensation of chemicals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:48:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0007635</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemosensory behavior</rdfs:label>
@@ -5675,8 +5686,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to the sensation of odors.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:48:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042048</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory behavior</rdfs:label>
@@ -5705,8 +5716,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050909"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T10:50:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>gustatory behavior</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Taste can be described as five basic sensations, sweet, sour, salty, bitter and umamy which can be combined in various ways to make all other taste sensations.</rdfs:comment>
@@ -5737,8 +5748,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to environmental temperature.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T11:00:51Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>thermosensation behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0040040</oboInOwl:xref>
@@ -5752,8 +5763,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000327">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000751"/>
         <obo:IAO_0000115>&quot;Behavior related to the sensations arising from the skin and from the muscles, tendons, and joints.&quot; [OBP:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T11:01:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Sensations arising from the internal organs (the viscera), such as pain or the sense of fullness of the stomach or bladder, may therefore be included, although they are usually considered separately as visceral sensations. Pain arising from the viscera is often felt as though it comes from some part of the body surface or underlying tissue.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somatic sensation related behavior</rdfs:label>
@@ -5783,8 +5794,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to the detection of high environmental temperature.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T11:09:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hot sensation behavior</rdfs:label>
     </owl:Class>
@@ -5813,8 +5824,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to the detection of low environmental temperature.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T11:09:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cold sensation behavior</rdfs:label>
     </owl:Class>
@@ -5825,8 +5836,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000330">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000327"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T11:11:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cutaneous sensation behavior</rdfs:label>
     </owl:Class>
@@ -5854,8 +5865,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0019233"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T11:13:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>nociception</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>pain</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -5885,8 +5896,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050975"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T11:36:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">touch related behavior</rdfs:label>
     </owl:Class>
@@ -5914,8 +5925,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050968"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T12:38:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>chemical nociception behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical nociceptive behavior</rdfs:label>
@@ -5944,8 +5955,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050966"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T12:39:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>mechanical nociception behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mechanical nociceptive behavior</rdfs:label>
@@ -5974,8 +5985,8 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050965"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T12:41:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>thermal nociception behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermal nociceptive behavior</rdfs:label>
@@ -5987,8 +5998,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000336">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000331"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T12:45:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>chemically-elicited antinociception behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemically-elicited antinociceptive behavior</rdfs:label>
@@ -6000,8 +6011,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000337">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000330"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T02:06:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pressure related behavior</rdfs:label>
     </owl:Class>
@@ -6013,8 +6024,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000338">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;Movement behavior of the body or its parts.&quot;</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T02:08:47Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinesthetic behavior</rdfs:label>
     </owl:Class>
@@ -6026,8 +6037,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000339">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
         <obo:IAO_0000115>&quot;The coordination of combinations of body movements created with the kinematic (such as spatial direction) and kinetic (force) parameters that result in intended actions.&quot; [wikipedia:Motor_coordination]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T03:32:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000340</oboInOwl:hasAlternativeId>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motor coordination</rdfs:label>
@@ -6040,8 +6051,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000341">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000348"/>
         <obo:IAO_0000115>&quot;The coordinated control of eye movement with hand movement, and the processing of visual input to guide reaching and grasping along with the use of proprioception of the hands to guide the eyes.&quot; [wikipedia:Eye%E2%80%93hand_coordination]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T03:43:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hand eye coordination</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Optic apraxia - total inability of a person to coordinate eye and hand movements.\nOptic ataxia - inability of a person to coordinate eye and hand movements.</rdfs:comment>
@@ -6055,8 +6066,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000342">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000347"/>
         <obo:IAO_0000115>&quot;The coordination of limb movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T03:49:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">limb coordination</rdfs:label>
     </owl:Class>
@@ -6068,8 +6079,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000343">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000346"/>
         <obo:IAO_0000115>&quot;Coordination that results in spatial and temporal planning of reaching and grasping.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T03:57:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>intra-limb coordination</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intralimb coordination</rdfs:label>
@@ -6082,8 +6093,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000344">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000346"/>
         <obo:IAO_0000115>&quot;Coordination that results in bimanual synchronization and temporal association of the hands.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T03:58:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>inter-limb coordination</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interlimb coordination</rdfs:label>
@@ -6096,8 +6107,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000345">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000342"/>
         <obo:IAO_0000115>&quot;The coordination of lower limb movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T04:05:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lower limb coordination</rdfs:label>
     </owl:Class>
@@ -6109,8 +6120,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000346">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000342"/>
         <obo:IAO_0000115>&quot;The coordination of upper limb movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T04:05:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper limb coordination</rdfs:label>
     </owl:Class>
@@ -6122,8 +6133,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000347">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
         <obo:IAO_0000115>&quot;The coordination of large muscle groups and whole body movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T04:10:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>large muscle coordination</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>whole body coordination</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -6137,8 +6148,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000348">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
         <obo:IAO_0000115>&quot;Coordination of small muscle movements which occur usually in coordination with the eye.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T04:14:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fine motor coordination</rdfs:label>
     </owl:Class>
@@ -6149,8 +6160,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000349">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000348"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T04:17:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">manual dexterity</rdfs:label>
     </owl:Class>
@@ -6162,8 +6173,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000350">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000339"/>
         <obo:IAO_0000115>&quot;Coordination involved in writing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T04:19:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">graphomotor coordination</rdfs:label>
     </owl:Class>
@@ -6175,8 +6186,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000351">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000347"/>
         <obo:IAO_0000115>&quot;The coordination of the whole body movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T05:28:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body coordination</rdfs:label>
     </owl:Class>
@@ -6188,8 +6199,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000352">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000351"/>
         <obo:IAO_0000115>&quot;The coordination of the lower body movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T05:30:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper body coordination</rdfs:label>
     </owl:Class>
@@ -6201,8 +6212,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000353">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000351"/>
         <obo:IAO_0000115>&quot;The coordination of the upper body movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T05:30:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lower body coordination</rdfs:label>
     </owl:Class>
@@ -6213,8 +6224,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000354">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000347"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-05T05:33:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bilateral coordination</rdfs:label>
     </owl:Class>
@@ -6226,8 +6237,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000355">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000317"/>
         <obo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the body and its limbs.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T09:30:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">posture</rdfs:label>
     </owl:Class>
@@ -6256,8 +6267,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the body.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T09:30:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body posture</rdfs:label>
     </owl:Class>
@@ -6286,8 +6297,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the limbs.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T09:31:06Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">limb posture</rdfs:label>
     </owl:Class>
@@ -6299,8 +6310,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000358">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000355"/>
         <obo:IAO_0000115>&quot;Intentionally or habitually assumed arrangement of the body and its limbs in inactivity.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T09:31:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">resting posture</rdfs:label>
     </owl:Class>
@@ -6312,8 +6323,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000359">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
         <obo:IAO_0000115>&quot;Behavior associated with surface locomotion.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T09:44:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">terrestrial locomotory behavior</rdfs:label>
     </owl:Class>
@@ -6325,8 +6336,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000360">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000366"/>
         <obo:IAO_0000115>&quot;Behavior related to the upward thrust produced by the rapid, simultaneous extension of the hind legs with the intend to cross wide gaps in the locomotor surface.&quot; [MBP:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T09:47:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>saltation</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">leaping behavior</rdfs:label>
@@ -6339,8 +6350,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000361">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000342"/>
         <obo:IAO_0000115>&quot;The pattern of movement of the limbs of animals, characterized by elements of progression, stability, speed and length over the ground.&quot; [MP:0001406]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T10:07:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gait</rdfs:label>
     </owl:Class>
@@ -6352,8 +6363,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000362">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000361"/>
         <obo:IAO_0000115>&quot;A behavioral pattern characterized by the distance covered by as many steps as there are legs.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T10:08:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stride</rdfs:label>
     </owl:Class>
@@ -6365,8 +6376,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000363">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000359"/>
         <obo:IAO_0000115>&quot;Behavior related to the movement resulting by dragging the body close to the ground.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T11:39:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">crawl</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crawling behavior</rdfs:label>
@@ -6379,8 +6390,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000364">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000368"/>
         <obo:IAO_0000115>&quot;Behavior related to the locomotion of animals in trees.&quot; [wikipedia:Arboreal_locomotion]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T11:40:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arboreal locomotion behavior</rdfs:label>
     </owl:Class>
@@ -6392,8 +6403,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000365">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000364"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arm over arm swinging movement through arboreal environment [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T11:42:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Arguably the epitome of arboreal locomotion, it involves swinging with the arms from one handhold to another.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brachiation</rdfs:label>
@@ -6406,8 +6417,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000366">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
         <obo:IAO_0000115>&quot;Behavior related to the movement of an organism from one location to another through the air.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T11:44:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aerial locomotion behavior</rdfs:label>
     </owl:Class>
@@ -6419,8 +6430,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000367">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000366"/>
         <obo:IAO_0000115>&quot;Behavior related to the self-propelled movement of an organism from one location to another through the air, usually by means of active wing movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T11:45:51Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000072</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym xml:lang="en">fly</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>flying</oboInOwl:hasExactSynonym>
@@ -6436,8 +6447,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000368">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
         <obo:IAO_0000115>&quot;Behavior related to the ascending a steep object.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T11:46:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">climbing behavior</rdfs:label>
     </owl:Class>
@@ -6449,8 +6460,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000369">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000366"/>
         <obo:IAO_0000115>&quot;Behavior related to the expansion lateral surface of the body with the intention of increasing the wind resistance against the body and hence reducing the speed of falling.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T12:20:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gliding behavior</rdfs:label>
     </owl:Class>
@@ -6462,8 +6473,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000370">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000016"/>
         <obo:IAO_0000115>&quot;Behavior related to the upward thrust produced by the rapid, simultaneous extension of the hind legs with the intend to rise in the air.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T12:25:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hopping</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">saltation</rdfs:label>
@@ -6476,8 +6487,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000371">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
         <obo:IAO_0000115>&quot;Behavior related to the movement of an organism from one location to another through a liquid medium.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T12:33:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swim</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>swimming</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -6491,8 +6502,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000372">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
         <obo:IAO_0000115>&quot;Behavior related to the control of the direction of locomotion.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:15:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">directional control of locomotion</rdfs:label>
     </owl:Class>
@@ -6504,8 +6515,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000373">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000372"/>
         <obo:IAO_0000115>&quot;Behavior related to the ability of an animal to determine and to alter its position in the environment.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:16:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotory orientation behavior</rdfs:label>
     </owl:Class>
@@ -6517,8 +6528,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000374">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000373"/>
         <obo:IAO_0000115>&quot;Alteration of speed or direction of movement in response to a sensory stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:17:18Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042465</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinesis</rdfs:label>
@@ -6531,8 +6542,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000375">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000373"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in a specific spatial relationship to a stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:17:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042330</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">taxis</rdfs:label>
@@ -6545,8 +6556,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000376">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000372"/>
         <obo:IAO_0000115>&quot;Behavior related to the mechanical alteration of the locomotor pattern through which the animal adjusts its position.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:18:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">steering behavior</rdfs:label>
     </owl:Class>
@@ -6558,8 +6569,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000377">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to specific chemical concentration gradient.&quot; [GO:0006935]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:23:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>chemotaxis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0006935</oboInOwl:xref>
@@ -6573,8 +6584,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000378">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to gravity.&quot; [GO:0048062]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:27:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>geotactic behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>gravitaxis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -6589,8 +6600,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000379">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000378"/>
         <obo:IAO_0000115>&quot;Locomotory orientation away from the source of gravity.&quot; [GO:0048060]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:32:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>negative geotactic behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>negative gravitaxis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -6605,8 +6616,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000380">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000378"/>
         <obo:IAO_0000115>&quot;Locomotory orientation towards the source of gravity.&quot; [GO:0048061]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:34:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>positive geotactic behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>positive gravitaxis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -6621,8 +6632,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000381">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000386"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to touch.&quot; [GO:0001966]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:45:18Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>stereotaxis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thigmotaxis</rdfs:label>
@@ -6635,8 +6646,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000382">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to physical parameters involved in energy generation.&quot; [GO:0009453]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:47:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0009453</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">energy taxis</rdfs:label>
@@ -6649,8 +6660,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000383">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000382"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to light.&quot; [GO:0042331]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:48:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>phototaxis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0042331</oboInOwl:xref>
@@ -6664,8 +6675,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000384">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000382"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to a temperature gradient.&quot; [GO:0043052]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:50:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0043052</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">thermotaxis</rdfs:label>
@@ -6678,8 +6689,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000385">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000386"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to sound.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:58:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">phonotaxis</rdfs:label>
     </owl:Class>
@@ -6691,8 +6702,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000386">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000375"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to mechanical stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T01:59:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mechanical stimulus taxis</rdfs:label>
     </owl:Class>
@@ -6704,8 +6715,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000387">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000386"/>
         <obo:IAO_0000115>&quot;Locomotory orientation in response to pressure.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T02:01:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">barotaxis</rdfs:label>
     </owl:Class>
@@ -6718,8 +6729,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/NBO_0000403"/>
         <obo:IAO_0000115>&quot;Behavior related to movements that occur independent of planning.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T02:35:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Movevents listed here are involuntary, but may be also generated by free will, like blinking of the eyelids and respiratory movements.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">involuntary movement behavior</rdfs:label>
@@ -6749,8 +6760,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior related to involuntary movement in response to a stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T02:36:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000004</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>reflex behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -6764,8 +6775,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000390">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;Reflex actions originating in the central nervous system that are exhibited by normal infants in response to particular stimuli.&quot; [wikipedia:Primitive_reflexes]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T02:44:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>infant reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>infantile reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>newborn reflex</oboInOwl:hasExactSynonym>
@@ -6780,8 +6791,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000391">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;An action or movement due to the application of a sudden unexpected stimulus.&quot; [wikipedia:Startle_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T02:55:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>alarm reaction</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">startle reflex</rdfs:label>
@@ -6794,8 +6805,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000392">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex that arises when tilting the head back while lying on the back causes the back to stiffen and even arch backwards, the legs to straighten, stiffen, and push together, the toes to point, the arms to bend at the elbows and wrists, and the hands to become fisted or the fingers to curl.&quot; [wikipedia:Tonic_labyrinthine_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:03:51Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>TLR</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tonic labyrinthine reflex</rdfs:label>
@@ -6808,8 +6819,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000393">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex that assists in the birthing process and helps to develop muscle tone, kicking and stimulates vestibular function in utero.&quot; [wikipedia:Asymmetrical_tonic_neck_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:05:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>ATNR</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fencing reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -6823,8 +6834,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000394">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex that causes the eyes to alternately fixate at far and near, expanding vision development from arms length to far away.&quot; [MBP:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:10:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">symmetrical tonic neck reflex</rdfs:label>
     </owl:Class>
@@ -6836,8 +6847,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000395">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;It is elicited by holding the newborn in ventral suspension (face down) and stroking along the one side of the spine. A reflex that caused the laterally flex toward the stimulated side when a newborn is held in ventral suspension (face down) and stroking along the one side of the spine.&quot; [NBO:Galant_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:11:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>spinal galant</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">galant reflex</rdfs:label>
@@ -6850,8 +6861,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000396">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex elicited by the application of pressure to both palms resulting varying responses such as head flexion, head rotation or opening of the mouth, or a combination of these responses.&quot; [wikipedia:Primitive_reflexes]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:14:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">babkin reflex</rdfs:label>
     </owl:Class>
@@ -6863,8 +6874,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000397">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex that causes the infant to begin to paddle and kick in a swimming motion upon its placement face down in a pool of water.&quot; [NBO:Primitive_reflexes]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:15:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swimming reflex</rdfs:label>
     </owl:Class>
@@ -6877,8 +6888,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A reflex elicited when the sole of the foot is stimulated with a blunt instrument.&quot; [wikipedia:Plantar_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:18:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">plantar reflex</rdfs:label>
     </owl:Class>
@@ -6890,8 +6901,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000399">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex elicited by the placement of an object in the infant&apos;s hand and strokes their palm, causing its fingers to close and grasp it.&quot; [wikipedia:Primitive_reflexes]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:20:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">palmar grasp reflex</rdfs:label>
     </owl:Class>
@@ -6903,8 +6914,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000400">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex that causes a newborn infant to turn his head toward anything that strokes his cheek or mouth, searching for the object by moving his head in steadily decreasing arcs until the object is found.&quot; [wikipedia:Primitive_reflexes]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:22:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rooting reflex</rdfs:label>
     </owl:Class>
@@ -6917,8 +6928,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000054"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex that causes the infant to instinctively suck at anything that touches the roof of their mouth and suddenly starts to suck simulating the way they naturally eat.&quot; [wikipedia:Primitive_reflexes]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:25:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sucking reflex</rdfs:label>
     </owl:Class>
@@ -6930,8 +6941,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000402">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex that causes the infant to attempt to &apos;walk&apos; by placing one foot in front of the other when the soles of their feet touch a flat surface.&quot; [wikipedia:Primitive_reflexes]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:26:47Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>stepping reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">walking reflex</rdfs:label>
@@ -6945,8 +6956,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0050882"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
         <obo:IAO_0000115>&quot;Behavior related to movements executed with intent.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T03:32:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">voluntary movement behavior</rdfs:label>
     </owl:Class>
@@ -6958,8 +6969,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000404">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A muscle contraction in response to stretching within the muscle.&quot; [wikipedia:Stretch_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:02:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>deep tendon reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stretch reflex</rdfs:label>
@@ -6972,8 +6983,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000405">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A deep tendon reflex that elicits involuntary contraction of the biceps brachii muscle.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:06:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biceps reflex</rdfs:label>
     </owl:Class>
@@ -6985,8 +6996,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000406">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A deep tendon reflex elicited by striking the lateral surface of the forearm proximal to the distal head of the radius, characterized by normal slight elbow flexion and forearm supination.&quot; [Medical disctionary:http\://medical-dictionary.thefreedictionary.com/brachioradialis+reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:07:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>supinator reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">brachioradialis reflex</rdfs:label>
@@ -6999,8 +7010,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000407">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A reflex that elicits involuntary contraction of the extensor digitorum muscle.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:09:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>BER</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Braunecker-Effenberg reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7014,8 +7025,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000408">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A deep tendon reflex that elicits involuntary contraction of the triceps brachii muscle.&quot; [wikipedia:Triceps_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:12:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">triceps reflex</rdfs:label>
     </owl:Class>
@@ -7027,8 +7038,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000409">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A deep tendon reflex that elicits extension of the leg resulting from a sharp tap on the patellar tendon.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:18:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>knee-jerk reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">patellar reflex</rdfs:label>
@@ -7041,8 +7052,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000410">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A reflex bending of the foot resulting from contraction of the calf muscles when the Achilles tendon is sharply struck.&quot; [Medical Dictionary:http\://medical-dictionary.thefreedictionary.com/Achilles+reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:20:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Achilles reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Achilles tendon reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>ankle reflex</oboInOwl:hasExactSynonym>
@@ -7058,8 +7069,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000411">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex that involves cranial nerves.&quot; [wikipedia:Reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:28:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cranial nerve related reflex</rdfs:label>
     </owl:Class>
@@ -7071,8 +7082,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000412">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
         <obo:IAO_0000115>&quot;A reflex that controls the diameter of the pupil, in response to the intensity (luminance) of light that falls on the retina of the eye, thereby assisting in adaptation to various levels of darkness and light, in addition to retinal sensitivity.&quot; [wikipedia:Pupillary_light_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:28:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pupillary reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pupillary light reflex</rdfs:label>
@@ -7085,8 +7096,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000413">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
         <obo:IAO_0000115>&quot;A reflex action of the eye, in response to focusing on a near object, then looking at distant object (and vice versa), comprising coordinated changes in vergence, lens shape and pupil size.&quot; [wikipedia:Accommodation_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:29:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">accommodation reflex</rdfs:label>
     </owl:Class>
@@ -7097,8 +7108,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000414">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T04:30:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>masseter reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jaw jerk reflex</rdfs:label>
@@ -7111,8 +7122,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000415">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
         <obo:IAO_0000115>&quot;An involuntary blinking of the eyelids elicited by stimulation of the cornea.&quot; [wikipedia:Corneal_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T06:08:06Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>blink reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>blinking</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7126,8 +7137,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000416">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
         <obo:IAO_0000115>&quot;A reflex eye movement that stabilizes images on the retina during head movement by producing an eye movement in the direction opposite to head movement, thus preserving the image on the center of the visual field.&quot; [wikipedia:Vestibulo-ocular_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T06:11:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>VOR</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>oculovestibular reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>vestibuloocular reflex</oboInOwl:hasExactSynonym>
@@ -7142,8 +7153,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000417">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000416"/>
         <obo:IAO_0000115>&quot;A form of involuntary eye movement that is part of the vestibulo-ocular reflex (VOR). It is characterized by alternating smooth pursuit in one direction and saccadic movement in the other direction.&quot; [wikipedia:Physiologic_nystagmus]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T06:16:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">physiologic nystagmus</rdfs:label>
     </owl:Class>
@@ -7155,8 +7166,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000418">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
         <obo:IAO_0000115>&quot;A reflex contraction of the back of the throat, evoked by touching the soft palate.&quot; [wikipedia:Gag_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-06T06:17:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>gag reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>swallowing reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7186,8 +7197,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000473"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the readily reversible state of reduced awareness and metabolic activity that occurs periodically in many animals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T01:19:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleeping behavior phenotype</rdfs:label>
     </owl:Class>
@@ -7199,8 +7210,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000420">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
         <obo:IAO_0000115>&quot;A NREM parasomnia characterised by Involuntarily grinding of teeth while sleeping.&quot; [MBP:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T01:20:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>&lt;new synonym&gt;</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>teeth grinding</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7215,8 +7226,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000421">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
         <obo:IAO_0000115>&quot;A circadian rhythm sleep disorder characterized by a much later than normal timing of sleep onset and offset and a period of peak alertness in the middle of the night.&quot; [wikipedia:Delayed_sleep_phase_syndrome]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T01:22:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>DSPS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>delayed sleep-phase disorder (DSPD)</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>delayed sleep-phase type (DSPT)</oboInOwl:hasExactSynonym>
@@ -7231,8 +7242,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000422">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
         <obo:IAO_0000115>&quot;Inability to fall asleep and/or remain asleep for a reasonable amount of time.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T01:23:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">insomnia</rdfs:label>
     </owl:Class>
@@ -7244,8 +7255,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000423">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
         <obo:IAO_0000115>&quot;A dyssomnia characterised by excessive daytime sleepiness (EDS) in which a person experiences extreme fatigue and possibly falls asleep at inappropriate times.&quot; [wikipedia:Narcolepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T01:24:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0005279</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">narcolepsy</rdfs:label>
@@ -7258,8 +7269,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000424">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
         <obo:IAO_0000115>&quot;A NREM parasomnia characterised by abrupt awakening from sleep with behavior consistent with terror and a temporary inability to regain full consciousness.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T01:25:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Pavor nocturnus</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>night terror</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7273,8 +7284,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000425">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex that results in the contraction of the muscles of the abdominal wall in response to stimulation of the overlying skin.&quot; [web:http\://www.merriam-webster.com/medical/abdominal%20reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:12:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdominal reflex</rdfs:label>
     </owl:Class>
@@ -7286,8 +7297,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000426">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;Reflexive contraction of the external anal sphincter upon stroking of the skin around the anus.&quot; [wikipedia:Anal_wink]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:12:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>anal reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>anal wink</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>perineal reflex</oboInOwl:hasExactSynonym>
@@ -7302,8 +7313,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000427">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex is elicited by lightly stroking the superior and medial (inner) part of the thigh resulting in a contraction of the cremaster muscle that pulls up the scrotum and testis on the side stroked.&quot; [wikipedia:Cremasteric_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:15:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cremasteric reflex</rdfs:label>
     </owl:Class>
@@ -7315,8 +7326,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000428">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex in mammals which optimises respiration to allow staying underwater for extended periods of time.&quot; [wikipedia:Mammalian_diving_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:16:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mammalian diving reflex</rdfs:label>
     </owl:Class>
@@ -7328,8 +7339,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000429">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000425"/>
         <obo:IAO_0000115>&quot;An increase in tonus (normal tension) of the tissues of the abdominal muscles resulting from painful stimuli originating in a viscus.&quot; [:http\://www.wordinfo.info/words/index/inf]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:18:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visceromotor reflex</rdfs:label>
     </owl:Class>
@@ -7341,8 +7352,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000430">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000429"/>
         <obo:IAO_0000115>&quot;A reflex of the abdominal muscles to contract upon mechanical force to the abdomen, and serves as protection.&quot; [wikipedia:Muscular_defense]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:20:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">muscular defense</rdfs:label>
     </owl:Class>
@@ -7355,8 +7366,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000057"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A response to activation of sensory neurons whose peripheral terminals are located on the surface of the body.&quot; [wikipedia:Scratch_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:21:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000021</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>self-scratching</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7370,8 +7381,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000432">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000391"/>
         <obo:IAO_0000115>&quot;An action or movement due to the application of a sudden unexpected loud noise.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:31:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acoustic startle reflex</rdfs:label>
     </owl:Class>
@@ -7383,8 +7394,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000433">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000404"/>
         <obo:IAO_0000115>&quot;A reflex where the body reacts to pain or unpleasant stimuli by trying to move itself away from the source.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:35:05Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>flexor withdrawal reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>nociceptive reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7398,8 +7409,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000434">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000433"/>
         <obo:IAO_0000115>&quot;A reflex where the flexors in the withdrawing limb contract and the extensors relax, while in the other limb, the opposite occurs.&quot; [wikipedia:Crossed_extensor_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:39:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crossed extensor reflex</rdfs:label>
     </owl:Class>
@@ -7411,8 +7422,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000435">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;An involuntary muscle contraction that occurs in the middle ear of mammals in response to high-intensity sound stimuli.&quot; [wikipedia:Acoustic_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:41:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>attenuation reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>auditory reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>stapedius reflex</oboInOwl:hasExactSynonym>
@@ -7427,8 +7438,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000436">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex in which joint movement can reflexively cause muscle activation or inhibition.&quot; [wikpedia:Arthrokinetic_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:42:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">arthrokinetic reflex</rdfs:label>
     </owl:Class>
@@ -7440,8 +7451,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000437">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex by which the body rids the lower respiratory tract of any irritant that enters through the air and less frequently any fluids (drinks) and solids (food) that may spill into the respiratory tract.&quot; [XX:http\://www.healthhype.com/cough-reflex-physiology-process-ear-cough-reflexes.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:45:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cough reflex</rdfs:label>
     </owl:Class>
@@ -7453,8 +7464,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000438">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A pouting or pursing of the lips that is elicited by light tapping of the closed lips near the midline.&quot; [wikipedia:Snout_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:47:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snout reflex</rdfs:label>
     </owl:Class>
@@ -7466,8 +7477,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000439">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000390"/>
         <obo:IAO_0000115>&quot;A reflex elicited by repetitive tapping on the forehead which result in blinking to the first several taps.&quot; [wikipedia:Glabellar_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-07T05:48:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>glabellar tap sign</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glabellar reflex</rdfs:label>
@@ -7480,8 +7491,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000440">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A skeletal muscle contraction causes the muscle to simultaneously lengthen and relax.&quot; [wikipedia:Golgi_tendon_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:01:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>inverse myotatic reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Golgi tendon reflex</rdfs:label>
@@ -7494,8 +7505,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000441">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex in which muscle groups around the vital organs begin to shake in small movements in an attempt to create warmth by expending energy.&quot; [wikipedia:Shivering]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:05:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>The shivering reflex is triggered to maintain homeostasis.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shivering reflex</rdfs:label>
@@ -7508,8 +7519,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000442">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex in which mucus containing foreign particles or irritants is expelled and the nasal cavity is cleanses.&quot; [wikipedia:Sneeze]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:08:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>sneeze</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>sneezing</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -7523,8 +7534,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000443">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A contraction of muscles in the gastrointestinal tract in response to distension of the tract following consumption of food and drink.&quot; [wikipedia:Vagus_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:10:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vagovagal reflex</rdfs:label>
     </owl:Class>
@@ -7535,8 +7546,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000444">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:22:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye movement</rdfs:label>
     </owl:Class>
@@ -7547,8 +7558,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000445">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:22:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tail movement</rdfs:label>
     </owl:Class>
@@ -7561,8 +7572,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/GO_0007601"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
         <obo:IAO_0000115>&quot;Selectively track a moving object.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:25:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual pursuit</rdfs:label>
     </owl:Class>
@@ -7580,8 +7591,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>Activation of locomotory behavior.</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:27:51Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">locomotor activation behavior</rdfs:label>
     </owl:Class>
@@ -7592,8 +7603,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000448">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000013"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:28:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vertical activity</rdfs:label>
     </owl:Class>
@@ -7605,8 +7616,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000449">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000338"/>
         <obo:IAO_0000115>Kinesthetic behavior initiated in the absence of specific sensory input.</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:28:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spontaneous movement behavior</rdfs:label>
     </owl:Class>
@@ -7619,8 +7630,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
         <obo:IAO_0000115>&quot;Behavior related to the activity in which individuals in a group clean or maintain one another&apos;s body or appearance.&quot; [wikipedia:Social_grooming]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:35:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">allo-hygiene behavior</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>allogrooming</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">allohygiene</oboInOwl:hasExactSynonym>
@@ -7635,8 +7646,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000451">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
         <obo:IAO_0000115>&quot;Behavior related to the promotion of personal hygiene.&quot; [wikipedia:Social_grooming]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:35:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000058</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>auto-grooming</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">autohygiene</oboInOwl:hasExactSynonym>
@@ -7653,8 +7664,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000452">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000065"/>
         <obo:IAO_0000115>&quot;Behavior related to the state or ability to perceive, to feel, or to be conscious of events, objects or sensory patterns.&quot; [wikipedia:Awareness]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:50:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">awareness</rdfs:label>
     </owl:Class>
@@ -7665,8 +7676,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000453">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000065"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T12:52:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior related to feelings experiencing</rdfs:label>
         <owl:deprecated>true</owl:deprecated>
@@ -7679,8 +7690,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000455">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
         <obo:IAO_0000115>&quot;The sustained focus of cognitive resources on information while filtering or ignoring extraneous information.  Intended to encompass only attention to perceptual stimuli. &quot; [wikipedia:Attention]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:02:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">attention behavior</rdfs:label>
     </owl:Class>
@@ -7692,8 +7703,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000456">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
         <obo:IAO_0000115>&quot;Behavior involving responding discretely to specific visual, auditory or tactile stimuli.&quot; [wikipedia:Attention]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:04:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">focused attention behavior</rdfs:label>
     </owl:Class>
@@ -7705,8 +7716,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000457">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
         <obo:IAO_0000115>&quot;Behavior involving maintaining a behavioral or cognitive set in the face of distracting or competing stimuli.&quot; [wikipedia:Attention]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:05:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">selective attention behavior</rdfs:label>
     </owl:Class>
@@ -7718,8 +7729,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000458">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
         <obo:IAO_0000115>&quot;Behavior involving mental flexibility that allows individuals to shift their focus of attention and move between tasks having different cognitive requirements.&quot; [wikipedia:Attention]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:05:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alternating attention behavior</rdfs:label>
     </owl:Class>
@@ -7731,8 +7742,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000459">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
         <obo:IAO_0000115>&quot;Behavior involving maintaining a consistent behavioral response during continuous and repetitive activity.&quot; [wikipedia:Attention]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:06:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>vigilance</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sustained attention behavior</rdfs:label>
@@ -7745,8 +7756,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000460">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000455"/>
         <obo:IAO_0000115>&quot;Behavior involving responding simultaneously to multiple tasks or multiple task demands.&quot; [wikipedia:Attention]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:08:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">divided attention behavior</rdfs:label>
     </owl:Class>
@@ -7776,8 +7787,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;The perception of familiar objects as approximately the same size regardless of their distance from the observer.&quot; [Jrank:http\://science.jrank.org/pages/5094/Perception.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:15:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">size constancy behavior</rdfs:label>
     </owl:Class>
@@ -7806,8 +7817,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;The perception of a color as constant under changing conditions of illumination.&quot; [wikipedia:Color_constancy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:16:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">colour constancy behavior</rdfs:label>
     </owl:Class>
@@ -7837,8 +7848,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;The perception of familiar objects as approximately the same shape regardless of their distance or angle of view from the observer.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:18:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shape constancy behavior</rdfs:label>
     </owl:Class>
@@ -7850,8 +7861,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000464">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
         <obo:IAO_0000115>&quot;Perception relating to the process of inferring the speed and direction of elements in a scene based on visual, vestibular and proprioceptive inputs.&quot; [wikipedia:Motion_perception]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:23:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perception of motion behavior</rdfs:label>
     </owl:Class>
@@ -7880,8 +7891,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Perception related to the identification of objects and their distinction from each other.&quot; [:http\://science.jrank.org/pages/5094/Perception.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:25:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">form perception behavior</rdfs:label>
     </owl:Class>
@@ -7910,8 +7921,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Behavior involving an active reception and coordination of information relating to depth received through the sensory systems in order to perceive the three-dimensionality of the world and objects within it.&quot; [:erceiving the three-dimensionality of the world and objects  Read more\: Perception - Perceptual Systems\, Historical Background\, Innate And Learned - Classical perceptual phenomena\, Broad theoretical approaches\, Current research/future developments http\://science.jrank.org/pages/5094/Perception.html#ixzz1It3oOobp]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:29:05Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">depth perception behavior</rdfs:label>
     </owl:Class>
@@ -7940,8 +7951,8 @@
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Perception of the distance of an object.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:31:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">distance perception behavior</rdfs:label>
     </owl:Class>
@@ -7953,8 +7964,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000468">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
         <obo:IAO_0000115>&quot;Misperception of stimuli, where what is perceived does not correspond to the actual dimensions or qualities of the physical stimulus.&quot; [jrank:http\://science.jrank.org/pages/5094/Perception.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:32:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perceptual illusion behavior</rdfs:label>
     </owl:Class>
@@ -7966,8 +7977,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000469">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;Behavior related to how the body reacts to a stressor ( a stimulus that causes stress), real or imagined.&quot; [wikipedia:Stress_(biological)]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:52:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>It refers to the consequence of the failure of an organism to respond adequately to mental, emotional or physical demands, whether actual or imagined.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stress related behavior</rdfs:label>
@@ -7980,8 +7991,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000470">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
         <obo:IAO_0000115>&quot;Behavior related to the identification or realization of a threat or a stressor.&quot; [wikipedia:Stress_(biological)]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T01:55:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral alarm</rdfs:label>
     </owl:Class>
@@ -7993,8 +8004,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000471">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000088"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000127"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:00:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">predator avoidance behavior</rdfs:label>
     </owl:Class>
@@ -8006,8 +8017,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000472">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000469"/>
         <obo:IAO_0000115>&quot;Behavior related to the depletion of the body resources for coping to stress.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:06:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral exhaustion</rdfs:label>
     </owl:Class>
@@ -8034,8 +8045,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:18:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rhythmic behavior phenotype</rdfs:label>
     </owl:Class>
@@ -8062,8 +8073,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000473"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:19:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pathological circadian behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian behavior phenotype</rdfs:label>
@@ -8076,8 +8087,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000475">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
         <obo:IAO_0000115>&quot;A pathological sleeping behavior related to the initiating or maintaining sleep or of excessive sleepiness and are characterized by a disturbance in the amount, quality, or timing of sleep.&quot; [wikipedia:Dyssomnia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:20:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dyssomnia</rdfs:label>
     </owl:Class>
@@ -8088,8 +8099,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000476">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:21:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intrinsic sleep disorder</rdfs:label>
     </owl:Class>
@@ -8101,8 +8112,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000477">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
         <obo:IAO_0000115>&quot;A dyssomnia characterized by excessive amounts of sleepiness.&quot; [wikipedia:Hypersomnia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:26:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypersomnia</rdfs:label>
     </owl:Class>
@@ -8114,8 +8125,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000478">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
         <obo:IAO_0000115>&quot;A dyssomnia where the patient moves limbs involuntarily during sleep, and has symptoms or problems related to the movement.&quot; [wikipedia:Periodic_limb_movement_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:27:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>PLMD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>nocturnal myoclonus</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -8129,8 +8140,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000479">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
         <obo:IAO_0000115>&quot;A dyssomnia characterized by an irresistible urge to move one&apos;s body to stop uncomfortable or odd sensations.&quot; [wikipedia:Restless_legs_syndrome]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:28:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>RLS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Wittmaack Ekbom syndrome</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -8144,8 +8155,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000480">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000494"/>
         <obo:IAO_0000115>&quot;A sleep breathing disorder characterized by abnormal pauses in breathing or instances of abnormally low breathing, during sleep.&quot; [wikipedia:Sleep_apnea]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:30:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>sleep apnoea</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep apnea</rdfs:label>
@@ -8158,8 +8169,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000481">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
         <obo:IAO_0000115>&quot;A dyssomnia characterized by a mistakenly perception of one&apos;s sleep as wakefulness.&quot; [wikipedia:Sleep_state_misperception]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:31:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>SSM</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>paradoxical insomnia</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>pseudo-insomnia</oboInOwl:hasExactSynonym>
@@ -8176,8 +8187,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000482">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:35:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">extrinsic sleep disorder</rdfs:label>
     </owl:Class>
@@ -8189,8 +8200,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000483">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000482"/>
         <obo:IAO_0000115>&quot;A dyssomnia associated with alcohol intake.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:36:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol-dependent sleep disorder</rdfs:label>
     </owl:Class>
@@ -8202,8 +8213,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000484">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000482"/>
         <obo:IAO_0000115>&quot;A insomnia associated with food allergies.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:37:51Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">food allergy insomnia</rdfs:label>
     </owl:Class>
@@ -8216,8 +8227,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000474"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000475"/>
         <obo:IAO_0000115>&quot;A pathological circadian behavior primarily related to the timing of sleep.&quot; [wikipedia:Circadian_rhythm_sleep_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:38:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian rhythm sleep disorder</rdfs:label>
     </owl:Class>
@@ -8229,8 +8240,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000486">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000485"/>
         <obo:IAO_0000115>&quot;An extrinsic circadian rhythm sleep disorder characterized by insomnia and excessive sleepiness affecting people whose work hours are scheduled during the typical sleep period.&quot; [wikipedia:Shift_work_sleep_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:54:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">extrinsic circadian rhythm sleep disorder</rdfs:label>
     </owl:Class>
@@ -8241,8 +8252,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000487">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000485"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:54:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intrinsic circadian rhythm sleep disorder</rdfs:label>
     </owl:Class>
@@ -8254,8 +8265,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000488">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000486"/>
         <obo:IAO_0000115>&quot;An extrinsic circadian rhythm sleep disorder resulting from rapid long distance transmeridian (east west or west east) travel.&quot; [wikipedia:Jet_lag]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:55:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jet lag</rdfs:label>
     </owl:Class>
@@ -8266,8 +8277,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000489">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000486"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T02:57:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>SWSD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">shift work sleep disorder</rdfs:label>
@@ -8280,8 +8291,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000490">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
         <obo:IAO_0000115>&quot;A circadian rhythm sleep disorder characterized by difficulty staying awake in the evening and staying asleep in the morning.&quot; [wikipedia:Advanced_sleep_phase_syndrome]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:00:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>ASPS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>ASPT</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>advanced sleep-phase type</oboInOwl:hasExactSynonym>
@@ -8296,8 +8307,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000491">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
         <obo:IAO_0000115>&quot;A circadian rhythm sleep disorder which the affected individual&apos;s sleep occurs later and later each day, with the period of peak alertness also continuously moving around the clock from day to day.&quot; [wikipedia:Circadian_rhythm_sleep_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:11:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>circadian rhythm sleep disorder, free running type</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>circadian rhythm sleep disorder, nonentrained type</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>free running disorder (FRD)</oboInOwl:hasExactSynonym>
@@ -8316,8 +8327,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000492">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000487"/>
         <obo:IAO_0000115>&quot;A circadian rhythm sleep disorder characterized by numerous naps throughout the 24-hour period, no main night time sleep episode and irregularity from day to day.&quot; [wikipedia:Irregular_sleep-wake_rhythm]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:16:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">irregular sleep-wake rhythm</rdfs:label>
     </owl:Class>
@@ -8329,8 +8340,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000493">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
         <obo:IAO_0000115>&quot;A sleeping behavior phenotype that involve abnormal and unnatural movements, emotions, perceptions, and dreams that occur while falling asleep, sleeping, between sleep stages, or during arousal from sleep.&quot; [wikipedia:Parasomnia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:20:06Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">parasomnia</rdfs:label>
     </owl:Class>
@@ -8342,8 +8353,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000494">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
         <obo:IAO_0000115>&quot;An intrinsic sleep disorder characterised by breathing abnormalities.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:27:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>SBD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep breathing disorder</rdfs:label>
@@ -8356,8 +8367,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000495">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000024"/>
         <obo:IAO_0000115>&quot;A sleeping behavior characterised by vibration of respiratory structures and the resulting sound, due to obstructed air movement during breathing while sleeping.&quot; [wikipedia:Snoring]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:28:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">snoring</rdfs:label>
     </owl:Class>
@@ -8369,8 +8380,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000496">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000494"/>
         <obo:IAO_0000115>&quot;A sleep breathing disorder characterized by airway resistance to breathing during sleep.&quot; [wikipedia:Upper_airway_resistance_syndrome]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:30:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">upper airway resistance syndrome</rdfs:label>
     </owl:Class>
@@ -8382,8 +8393,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000497">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000477"/>
         <obo:IAO_0000115>&quot;A hypersomnia characterized by recurrent episodes.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:32:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recurrent hypersomnia</rdfs:label>
     </owl:Class>
@@ -8395,8 +8406,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000498">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000477"/>
         <obo:IAO_0000115>&quot;A hypersomnia that occurs as a result of a traumatic event involving the central nervous system.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:32:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">posttraumatic hypersomnia</rdfs:label>
     </owl:Class>
@@ -8408,8 +8419,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000499">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000493"/>
         <obo:IAO_0000115>&quot;A type of parasomnia that occurs during NREM sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-08T03:37:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NREM parasomnia</rdfs:label>
     </owl:Class>
@@ -8421,8 +8432,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000500">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
         <obo:IAO_0000115>&quot;A NREM parasomnia characterised by the risef rom the slow wave sleep stage in a state of low consciousness and perform activities that are usually performed during a state of full consciousness.&quot; [wikipedia:Sleepwalking]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T09:32:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>somnambulism</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleepwalking</rdfs:label>
@@ -8435,8 +8446,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000501">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
         <obo:IAO_0000115>&quot;A NREM parasomnia characterised by involuntary urination while asleep after the age at which bladder control usually occurs.&quot; [wikipedia:Bedwetting]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T09:39:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>bedwetting</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nocturnal enuresis</rdfs:label>
@@ -8449,8 +8460,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000502">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000499"/>
         <obo:IAO_0000115>&quot;A NREM parasomnia characterised by talking during sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:02:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>sleep-talking</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somniloquy</rdfs:label>
@@ -8463,8 +8474,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000503">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000504"/>
         <obo:IAO_0000115>&quot;A REM parasomnia characterised by the lack of muscle atonia during sleep.&quot; [wikipedia:REM_Sleep_Behavior_Disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:06:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>RBD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM sleep behavior disorder</rdfs:label>
@@ -8477,8 +8488,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000504">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000493"/>
         <obo:IAO_0000115>&quot;A type of parasomnia that occurs during REM sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:07:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REM parasomnia</rdfs:label>
     </owl:Class>
@@ -8490,8 +8501,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000505">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000503"/>
         <obo:IAO_0000115>&quot;A RBD that occurs mostly as a result of a side-effect in prescribed medication- usually antidepressants.&quot; [wikipedia:Parasomnia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:10:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">acute RBD</rdfs:label>
     </owl:Class>
@@ -8503,8 +8514,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000506">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000503"/>
         <obo:IAO_0000115>&quot;Idiopathic or associated with neurological disorders REM sleep behavior disorder.&quot; [wikipedia:Parasomnia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:11:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chronic RBD</rdfs:label>
     </owl:Class>
@@ -8516,8 +8527,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000507">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000504"/>
         <obo:IAO_0000115>&quot;A REM parasomnia consisting of breath holding and expiratory groaning during sleep that is distinct from both somniloquy and obstructive sleep apnea.&quot; [wikipedia:Catathrenia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:13:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catathrenia</rdfs:label>
     </owl:Class>
@@ -8529,8 +8540,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000508">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000509"/>
         <obo:IAO_0000115>&quot;An isolted sleep paralysis that is characterized by frequent episodes or a complex of sequential episodes whose total duration may exceed one hour, and particularly by the range and sense of perceived reality of the subjective phenomena experienced during episodes.&quot; [web:http\://www.theconsciousdreamer.org/SSE.HTM]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:14:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>RISP</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recurrent isolated sleep paralysis</rdfs:label>
@@ -8543,8 +8554,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000509">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000510"/>
         <obo:IAO_0000115>&quot;A sleep paralaysis characterised by the absence of narcolepsy.&quot; [wikipedia:Sleep_paralysis]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:20:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>ISP</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">isolated sleep paralysis</rdfs:label>
@@ -8558,8 +8569,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000504"/>
         <obo:IAO_0000115>&quot;A REM parasomnia characterised by periods of inability to perform voluntary movements either when going to sleep or when waking up.&quot; [wikipedia:Sleep_paralysis]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:24:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sleep paralysis</rdfs:label>
     </owl:Class>
@@ -8571,8 +8582,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000511">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000510"/>
         <obo:IAO_0000115>&quot;A sleep paralysis which upon falling asleep the person remains aware while the body shuts down for REM sleep.&quot; [wikipedia:Sleep_paralysis]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:25:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>predormital sleep paralysis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypnagogic sleep paralysis</rdfs:label>
@@ -8585,8 +8596,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000512">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000510"/>
         <obo:IAO_0000115>&quot;A sleep paralysis which upon awakening, the person becomes aware before the REM cycle is complete,.&quot; [wikipedia:Sleep_paralysis]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:28:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>postdormital sleep paralysis</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypnopompic sleep paralysis</rdfs:label>
@@ -8599,8 +8610,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000513">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000368"/>
         <obo:IAO_0000115>&quot;Behavior related to the ascending stairs.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T10:51:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">climbing stairs</rdfs:label>
     </owl:Class>
@@ -8612,8 +8623,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000514">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000476"/>
         <obo:IAO_0000115>&quot;A dyssomnia characterised by fear of sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T11:20:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>somniphobia</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypnophobia</rdfs:label>
@@ -8641,8 +8652,8 @@
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000256"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-09T12:28:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000523</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>DD-NOS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>depressive disorder not otherwise specified</oboInOwl:hasExactSynonym>
@@ -8658,8 +8669,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000516">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
         <obo:IAO_0000115>&quot;A major depressive disorder characterized by mood reactivity (paradoxical anhedonia) and positivity, significant weight gain or increased appetite (\&quot;comfort eating\&quot;), excessive sleep or somnolence (hypersomnia), a sensation of heaviness in limbs known as leaden paralysis, and significant social impairment as a consequence of hypersensitivity to perceived interpersonal rejection.&quot; [wikipedia:Atypical_depression]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T12:55:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>AD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atypical depression</rdfs:label>
@@ -8672,8 +8683,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000517">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
         <obo:IAO_0000115>&quot;A major depressive disorder characterized by a loss of pleasure (anhedonia) in most or all activities, a failure of reactivity to pleasurable stimuli, a quality of depressed mood more pronounced than that of grief or loss, a worsening of symptoms in the morning hours, early morning waking, psychomotor retardation, excessive weight loss (not to be confused with anorexia nervosa), or excessive guilt.&quot; [wikipedia:Melancholic_depression]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T12:57:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">melancholic depression</rdfs:label>
     </owl:Class>
@@ -8685,8 +8696,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000518">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
         <obo:IAO_0000115>&quot;A major depressive disorder characterized by a major depressive episode, particularly of melancholic nature, where the patient experiences psychotic symptoms such as delusions or, less commonly, hallucinations.&quot; [wikipedia:Psychotic_major_depression]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T12:58:44Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>PMD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">psychotic major depression</rdfs:label>
@@ -8699,8 +8710,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000519">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
         <obo:IAO_0000115>&quot;A major depressive disorder characterized by psychological and motorological disturbances.&quot; [wikipedia:Catatonia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:01:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catatonic depression</rdfs:label>
     </owl:Class>
@@ -8712,8 +8723,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000520">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
         <obo:IAO_0000115>&quot;A major depressive disorder characterized by a intense, sustained and sometimes disabling depression experienced by women after giving birth.&quot; [wikipedia:Postpartum_depression]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:03:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>PDD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>postnatal depression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -8727,8 +8738,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000521">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000257"/>
         <obo:IAO_0000115>&quot;A major depressive disorder usually characterized seasonal pattern with depressive episodes coming on in the winter or summer, spring or autumn, repeatedly, year after year.&quot; [wikipedia:Seasonal_affective_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:10:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>winter blues</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>winter depression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -8742,8 +8753,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000522">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
         <obo:IAO_0000115>&quot;A depressive disorder characterized by chronic, different mood disturbance.&quot; [wikipedia:Dysthymia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:13:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>For humans: where a person reports a low mood almost daily over a span of at least two years.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dysthymia</rdfs:label>
@@ -8756,8 +8767,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000524">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
         <obo:IAO_0000115>&quot;A depressive disorder characterized by intermittent depressive episodes, in women not related to menstrual cycles, occurring at least once a month over at least one year or more fulfilling the diagnostic criteria for major depressive episodes except for duration which in RBD is less than 14 days, typically 2 to 4 days.&quot; [wikipedia:Recurrent_brief_depression]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:17:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>RBD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recurrent brief depression</rdfs:label>
@@ -8770,8 +8781,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000525">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
         <obo:IAO_0000115>&quot;A depressive disorder that does not meet full criteria for Major depressive disorder but in which at least two depressive symptoms are present for two weeks.&quot; [wikipedia:Minor_Depressive_Disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:19:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>minor depression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">minor depressive disorder</rdfs:label>
@@ -8784,8 +8795,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000526">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
         <obo:IAO_0000115>&quot;A type of bipolar disorder distinguished by the presence or history of one or more manic episodes or mixed episodes with or without major depressive episodes.&quot; [wikipedia:Bipolar_I]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:25:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bipolar I</rdfs:label>
     </owl:Class>
@@ -8797,8 +8808,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000527">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
         <obo:IAO_0000115>&quot;A bipolar disorder characterised by recurrent intermittent hypomanic and depressive episodes.&quot; [wikipedia:Mood_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:26:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bipolar II</rdfs:label>
     </owl:Class>
@@ -8810,8 +8821,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000528">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
         <obo:IAO_0000115>&quot;A bipolar disorder characterised by recurrent hypomanic and dysthymic episodes, but no full manic episodes or full major depressive episodes.&quot; [wikipedia:Cyclothymia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:27:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cyclothymia</rdfs:label>
     </owl:Class>
@@ -8823,8 +8834,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000529">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000258"/>
         <obo:IAO_0000115>&quot;A bipolar disorder characterised by symptoms in the bipolar spectrum (e.g. manic and depressive symptoms) but does not fully qualify for any of the three types of bipolar disorder.&quot; [wikipedia:Bipolar_Disorder_Not_Otherwise_Specified]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:28:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>BD-NOS</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bipolar disorder not otherwise specified</rdfs:label>
@@ -8836,8 +8847,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000530">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000256"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:33:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">substance induced mood disorder</rdfs:label>
     </owl:Class>
@@ -8848,8 +8859,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000531">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000530"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:34:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol induced mood disorder</rdfs:label>
     </owl:Class>
@@ -8860,8 +8871,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000532">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000530"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:34:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">benzodiazepine induced mood disorder</rdfs:label>
     </owl:Class>
@@ -8872,8 +8883,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000533">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000530"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:34:41Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon-alpha induced mood disorder</rdfs:label>
     </owl:Class>
@@ -8885,8 +8896,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000534">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
         <obo:IAO_0000115>&quot;A pathological anxiety which results from a traumatic experience.&quot; [wikipedia:Post-traumatic_stress_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:42:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>PTSD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>post-traumatic stress disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -8900,8 +8911,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000535">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000244"/>
         <obo:IAO_0000115>&quot;A pathological anxiety characterized by feeling of excessive and inappropriate levels of anxiety over being separated from a person or place.&quot; [wikipedia:Separation_anxiety_disorder]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T01:44:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>SepAD</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">separation anxiety</rdfs:label>
@@ -8914,8 +8925,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000536">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
         <obo:IAO_0000115>&quot;Any process in which an organism modulates its heart rate at different values with a regularity of approximately 24 hours.&quot; [GOC:rl]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T02:18:47Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0003053</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian regulation of heart rate</rdfs:label>
@@ -8928,8 +8939,8 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000537">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
         <obo:IAO_0000115>&quot;Any process in which an organism modulates its blood pressure at different values with a regularity of approximately 24 hours.&quot; [GO:GO\:0003052]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T02:21:01Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian regulation of systemic arterial blood pressure</rdfs:label>
     </owl:Class>
@@ -8942,8 +8953,8 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000051"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000084"/>
         <obo:IAO_0000115>&quot;Any homeostatic process in which an organism modulates its internal body temperature at different values with a regularity of approximately 24 hours.&quot; [GOC:dbh]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T02:22:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>circadian thermoregulation</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">circadian temperature homeostasis</rdfs:label>
@@ -8972,8 +8983,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000270"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">&quot;Observable characteristic of feeding behavior that relates to eating.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:39:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>eating disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eating behavior phenotype</rdfs:label>
@@ -9002,8 +9013,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000270"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">&quot;Observable characteristic of feeding behavior that relates to drinking.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:40:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>drinking disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>pathological drinking behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -9047,8 +9058,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000961"/>
         <obo:IAO_0000115>&quot;A pathological drinking behavior characterised by an excessive desire to drink.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:note>&apos;participates in&apos; some 
 (&apos;regulation of drinking behavior&apos; and (has_quality some 
@@ -9102,8 +9113,8 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000540"/>
         <obo:IAO_0000115>&quot;A pathological drinking behavior characterised by large intake of fluids by mouth, usually due to excessive thirst that is relatively prolonged.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:note>&apos;participates in&apos; some (
 &apos;regulation of drinking behavior&apos; and regulates some 
@@ -9152,8 +9163,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000961"/>
         <obo:IAO_0000115>&quot;A pathological drinking behavior characterised by an excessive relative temporal desire to drink.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:note>&apos;participates in&apos; some 
 (&apos;regulation of drinking behavior&apos; and (has_quality some 
@@ -9185,8 +9196,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
         <obo:IAO_0000115>&quot;A pathological feeding behavior characterised by failure to eat.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0001438</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aphagia</rdfs:label>
@@ -9205,8 +9216,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of moving food from the mouth cavity to the esophagus through coordinated muscular movements [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:39:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">swallow</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">swallowing</rdfs:label>
@@ -9235,8 +9246,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000539"/>
         <obo:IAO_0000115>&quot;A pathological eating behavior characterised by an abnormally large intake of food by mouth, usually due to excessive hunger that is relatively prolonged.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hyperphagia</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000724</oboInOwl:xref>
@@ -9267,8 +9278,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000522"/>
         <obo:IAO_0000115>&quot;Lack of ability to enjoy a sense of pleasure.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0009710</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anhedonia</rdfs:label>
@@ -9281,8 +9292,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000548">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
         <obo:IAO_0000115>&quot;Behaviour related to the male activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male sexual activity</rdfs:label>
     </owl:Class>
@@ -9294,8 +9305,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000549">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000034"/>
         <obo:IAO_0000115>&quot;Behaviour related to the female activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-10T10:41:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female sexual activity</rdfs:label>
     </owl:Class>
@@ -9307,8 +9318,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000550">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
         <obo:IAO_0000115>&quot;Ability to correctly remember something that has been encountered before.&quot; [wikipedia:Recognition_memory]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:53:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">recognition memory</rdfs:label>
     </owl:Class>
@@ -9320,8 +9331,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000551">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000550"/>
         <obo:IAO_0000115>&quot;Ability to perceive the physical properties of an object (such as shape, colour and texture) and apply semantic attributes to the object, which includes the understanding of its use, previous experience with the object and how it relates to others.&quot; [wikipedia:Cognitive_Neuroscience_of_Visual_Object_Recognition]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:56:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual object recognition</rdfs:label>
     </owl:Class>
@@ -9333,8 +9344,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000552">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000551"/>
         <obo:IAO_0000115>&quot;A visual object recognition that lasts hours to months and critically depends on a transfer of the information from short term object recognition memory using repeated rehearsals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T02:02:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term object recognition memory</rdfs:label>
     </owl:Class>
@@ -9345,8 +9356,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000553">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000554"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T02:03:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term object recognition memory</rdfs:label>
     </owl:Class>
@@ -9357,8 +9368,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000554">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000180"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T02:09:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual short term memory</rdfs:label>
     </owl:Class>
@@ -9370,8 +9381,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000555">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000180"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000556"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T02:10:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial working memory</rdfs:label>
     </owl:Class>
@@ -9383,8 +9394,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000556">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000306"/>
         <obo:IAO_0000115>&quot;A type of memory responsible for recording information about one&apos;s environment and its spatial orientation.&quot; [wikipedia:Spatial_memory]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T02:14:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial memory</rdfs:label>
     </owl:Class>
@@ -9396,8 +9407,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000557">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000556"/>
         <obo:IAO_0000115>&quot;A type of memory that allows one to temporarily store and manage information about one&apos;s environment and its spatial orientation.&quot; [wikipedia:Spatial_memory]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T02:17:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term spatial memory</rdfs:label>
     </owl:Class>
@@ -9408,8 +9419,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000558">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000185"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T02:19:43Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term spatial memory</rdfs:label>
     </owl:Class>
@@ -9422,8 +9433,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000152"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000450"/>
         <obo:IAO_0000115>&quot;Behavior related to the activity in which a mother cleans or maintains the body or the appearance of her offsprings.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T07:58:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">maternal grooming</rdfs:label>
     </owl:Class>
@@ -9435,8 +9446,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000560">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000027"/>
         <obo:IAO_0000115>&quot;Behavior relating to the plucking of fur/hair or whiskers/vibrissae.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:03:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">barbering behavior</rdfs:label>
     </owl:Class>
@@ -9448,8 +9459,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000561">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000560"/>
         <obo:IAO_0000115>&quot;Behavior related to the barbering of other individuals of a cohort.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:04:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000083</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>whisker trimming</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -9464,8 +9475,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000562">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000560"/>
         <obo:IAO_0000115>&quot;Behavior related to the barbering of oneself.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:05:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">self-barbering</rdfs:label>
     </owl:Class>
@@ -9477,8 +9488,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000563">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000595"/>
         <obo:IAO_0000115>&quot;A pathological behavior characterized by muscular rigidity and fixation of posture regardless of external stimuli, as well as decreased sensitivity to pain.&quot; [wikipedia:Catalepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:14:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0002822</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">catalepsy</rdfs:label>
@@ -9507,8 +9518,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior that occurs predominantly or only, in individuals that are part of a group.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:24:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pathological social behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social behavior phenotype</rdfs:label>
@@ -9520,8 +9531,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000565">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000564"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:24:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0001361</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social withdrawal</rdfs:label>
@@ -9533,8 +9544,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000566">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000565"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:25:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social withdrawal in childhood</rdfs:label>
     </owl:Class>
@@ -9546,8 +9557,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000567">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
         <obo:IAO_0000115>&quot;A pathological behavior associated with repetitive or ritualistic movement, posture, or utterance.&quot; [wikipedia:Stereotypy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:28:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>stereotypic behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>stereotypy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -9579,8 +9590,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the movement of the body&apos;s muscles, tendons, and joints.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:31:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kinesthetic behavior phenotype</rdfs:label>
     </owl:Class>
@@ -9592,8 +9603,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000569">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000644"/>
         <obo:IAO_0000115>&quot;Exhibiting abnormal exhaustion due to mental or physical exertion.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:32:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0002899</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fatigue</rdfs:label>
@@ -9606,8 +9617,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000570">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Movement of the head in the vertical plane. [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:39:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>head nodding</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym xml:lang="en">nod head</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -9621,8 +9632,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000571">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000020"/>
         <obo:IAO_0000115>&quot;Movement of the head in multiple directions.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T08:43:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multidirectional head movement</rdfs:label>
     </owl:Class>
@@ -9634,8 +9645,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000572">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
         <obo:IAO_0000115>&quot;A degenerative state of the brain resulting in impairment of memory, judgment, attention span, problem solving skills, the inability to perform previously learned skills that cannot be attributed to deficits of motor or sensory function, and a global loss of cognitive abilities.&quot; [MeSH:National Library of Medicine_Medical Subject Headings]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T09:01:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0002571</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">senility</rdfs:label>
@@ -9647,8 +9658,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000573">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000515"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T09:04:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0002573</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral despair</rdfs:label>
@@ -9661,8 +9672,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000574">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000411"/>
         <obo:IAO_0000115>&quot;A reflex allows the eye to follow objects in motion when the head remains stationary.&quot; [wikipedia:Optokinetic_reflex]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T09:20:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">optokinetic reflex</rdfs:label>
     </owl:Class>
@@ -9674,8 +9685,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000575">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex that elucidates goose bumps (bumps on a person&apos;s skin at the base of body hairs) which may involuntarily develop when a person is cold or experiences strong emotions such as fear, awe, admiration or sexual arousal&quot; [wikipedia:Goose_bumps]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:15:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>horripilation</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>piloerection</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -9689,8 +9700,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000576">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex that elucidates a characteristic ear twitch in response to an auditory stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:19:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Preyer&apos;s reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pinna reflex</rdfs:label>
@@ -9703,8 +9714,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000577">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A reflex that maintains body position and equilibrium either during rest or during movement.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:24:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">postural reflex</rdfs:label>
     </owl:Class>
@@ -9716,8 +9727,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000578">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
         <obo:IAO_0000115>&quot;A reflex process in which an animal immediately tries to turn over after being placed in a supine position.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:28:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>righting response</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">righting reflex</rdfs:label>
@@ -9730,8 +9741,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000579">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000005"/>
         <obo:IAO_0000115>&quot;A pathological behavior characterised by pronounced startle responses to tactile or acoustic stimuli and hypertonia.&quot; [wikipedia:Hyperekplexia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:37:34Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hyperekplexia</rdfs:label>
     </owl:Class>
@@ -9743,8 +9754,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000580">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
         <obo:IAO_0000115>&quot;A reflex that elucidates an automatic positioning of the limbs in response to a movement of the head on trunk (neck).&quot; [web:http\://www.dizziness-and-balance.com/anatomy/vspine.htm]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:42:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>TNR</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>cervicospinal reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -9758,8 +9769,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000581">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
         <obo:IAO_0000115>&quot;A reflex which results from activation of afferents from the vestibular organs and uses neck movements to stabilize the head position in space.&quot; [JAX:]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:44:18Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>VCR</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibulocollic reflex</rdfs:label>
@@ -9772,8 +9783,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000582">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000577"/>
         <obo:IAO_0000115>&quot;A reflex that originates with vestibular stimulation and control body posture.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:47:03Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vestibulospinal reflex</rdfs:label>
     </owl:Class>
@@ -9785,8 +9796,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000583">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;Change position in response to stimulation of the whiskers.&quot; [JAX:&lt;new dbxref&gt;]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:52:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>vibrissa reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vibrissae reflex</rdfs:label>
@@ -9799,8 +9810,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000584">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000389"/>
         <obo:IAO_0000115>&quot;A mouse reflex that elicidated the clasping of front and/or hind feet almost immediately upon being lifted by tail.&quot; [EUROPHENOME:]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T10:55:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>hindlimb extension reflex</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>limb clasping</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>limb grasping</oboInOwl:hasExactSynonym>
@@ -9815,8 +9826,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000585">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000587"/>
         <obo:IAO_0000115>&quot;A form of tetanic spasm in which the head and feet are drawn forward and the spine arches backward.&quot; [JAX:]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:05:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0009354</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emprosthotonos</rdfs:label>
@@ -9829,8 +9840,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000586">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000587"/>
         <obo:IAO_0000115>&quot;A form of tetanic spasm in which the head, neck and spine are bent backward and the body is bowed forward.&quot; [JAX:]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:08:01Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002179</oboInOwl:xref>
         <oboInOwl:xref>MP:0002880</oboInOwl:xref>
@@ -9844,8 +9855,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000587">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000588"/>
         <obo:IAO_0000115>&quot;A sudden, involuntary contraction of a muscle or group of muscles associated with strychnine poisoning and tetanus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:09:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tetanic spasm</rdfs:label>
     </owl:Class>
@@ -9857,8 +9868,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000588">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
         <obo:IAO_0000115>&quot;A sudden, involuntary contraction of a muscle or group of muscles.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:10:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spasm</rdfs:label>
     </owl:Class>
@@ -9870,8 +9881,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000589">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
         <obo:IAO_0000115>&quot;An involuntary rhythmical, oscillatory movement of a body part.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:13:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>quivering</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>shivering</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>trembling</oboInOwl:hasExactSynonym>
@@ -9904,8 +9915,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;Inability to coordinate voluntary muscular movements.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:25:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0001251</oboInOwl:xref>
         <oboInOwl:xref>MP:0001393</oboInOwl:xref>
@@ -9935,8 +9946,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000229"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the coordination of combinations of body movements created with the kinematic (such as spatial direction) and kinetic (force) parameters that result in intended actions.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:32:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">motor coordination phenotype</rdfs:label>
     </owl:Class>
@@ -9948,8 +9959,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000592">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000591"/>
         <obo:IAO_0000115>&quot;Lack of coordination of movement typified by the undershoot or overshoot of intended position with the hand, arm, leg, or eye.&quot; [wikipedia:Dysmetria]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:33:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0003314</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">dysmetria</rdfs:label>
@@ -9962,8 +9973,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000593">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000592"/>
         <obo:IAO_0000115>&quot;Overshooting the intended position.&quot; [wikipedia:Dysmetria]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:34:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypermetria</rdfs:label>
     </owl:Class>
@@ -9975,8 +9986,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000594">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000592"/>
         <obo:IAO_0000115>&quot;Undershooting the intended position.&quot; [wikipedia:Dysmetria]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:34:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypometria</rdfs:label>
     </owl:Class>
@@ -9988,8 +9999,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000595">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000229"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related with the Intentionally or habitually assumed arrangement of the body and its limbs.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:37:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">posture phenotype</rdfs:label>
     </owl:Class>
@@ -10001,8 +10012,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000596">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000595"/>
         <obo:IAO_0000115>&quot;Posture distinguished by a faltering gait while walking and/or a swaying motion of the trunk or head while resting.&quot; [JAX:&lt;new dbxref&gt;]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T11:37:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0009514</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">titubation</rdfs:label>
@@ -10015,8 +10026,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000597">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000032"/>
         <obo:IAO_0000115>&quot;Loss of power of voluntary movement in the muscles of the hindlimb through injury or disease of it or its nerve supply.&quot; [JAX:]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:20:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0000755</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hindlimb paralysis</rdfs:label>
@@ -10029,8 +10040,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000598">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000009"/>
         <obo:IAO_0000115>&quot;A locomotory disorder in which sustained muscle contractions cause twisting and repetitive movements or abnormal postures.&quot; [wikipedia:Dystonia]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:24:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0001332</oboInOwl:xref>
         <oboInOwl:xref>MP:0005323</oboInOwl:xref>
@@ -10044,8 +10055,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000599">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000556"/>
         <obo:IAO_0000115>&quot;A type of memory that allows one to store and manage information about one&apos;s environment and its spatial orientation lasting hours to months.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T01:43:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long-term spatial memory</rdfs:label>
     </owl:Class>
@@ -10057,8 +10068,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000600">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000129"/>
         <obo:IAO_0000115>&quot;Agitation characterised by a series of unintentional and purposeless motions that stem from mental tension and anxiety of an individual.&quot; [wikipedia:Psychomotor_agitation]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:03:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">psychomotor agitation behavior</rdfs:label>
     </owl:Class>
@@ -10086,8 +10097,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the complex psychophysiological experience of an individual&apos;s state of mind as interacting with biochemical (internal) and environmental (external) influences.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:07:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emotional behavior phenotype</rdfs:label>
     </owl:Class>
@@ -10099,8 +10110,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000602">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
         <obo:IAO_0000115>&quot;Exhibiting indifference, or suppression of emotions such as concern, excitement, motivation and passion.&quot; [wikipedia:Indifference_(emotion)]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:07:51Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>impassivity</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>perfunctoriness</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10115,8 +10126,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000603">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
         <obo:IAO_0000115>&quot;A belief that is either mistaken or not substantiated that is held with vehemence.&quot; [wikipedia:Delusion]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:20:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000746</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">delusion</rdfs:label>
@@ -10129,8 +10140,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000604">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <obo:IAO_0000115>&quot;A social behavior characterised by conscious or unconscious constraint of a behavior that might be considered objectionable in a social setting.&quot; [wikipedia:Social_inhibition]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:33:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social inhibition</rdfs:label>
     </owl:Class>
@@ -10142,8 +10153,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000605">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <obo:IAO_0000115>&quot;A social behavior characterised by conscious or unconscious constraint or curtailment of behavior relating to specific sexual matters or practices.&quot; [wikipedia:Sexual_inhibition]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:34:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual inhibition</rdfs:label>
     </owl:Class>
@@ -10171,8 +10182,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
         <obo:IAO_0000115>&quot;Loss of information already encoded and stored in an individual&apos;s long term memory.&quot; [wikipedia:Forgetting]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:42:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pathological forgetting</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>retention loss</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10187,8 +10198,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000607">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000313"/>
         <obo:IAO_0000115>&quot;Behaviour related to cognitive processes.&quot; [NBO:JH]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:51:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cognitive behavior</rdfs:label>
     </owl:Class>
@@ -10200,8 +10211,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000608">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
         <obo:IAO_0000115>&quot;Perception in the absence of a stimulus.&quot; [wikipedia:Hallucination]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:52:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0000738</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hallucination</rdfs:label>
@@ -10231,8 +10242,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A form of hallucination that involves perceiving images without visual stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:54:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>paracusia</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0008765</oboInOwl:xref>
@@ -10263,8 +10274,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A form of hallucination that involves perceiving sounds without auditory stimulus.&quot; [wikipedia:Auditory_hallucination]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:56:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002367</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">auditory hallucination</rdfs:label>
@@ -10294,8 +10305,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000115>&quot;A form of hallucination that involves perceiving odors without odor stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T03:58:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>phantosmia</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory hallucination</rdfs:label>
@@ -10308,8 +10319,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000612">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000011"/>
         <obo:IAO_0000115>&quot;A social behavior related to the activity of conveying information.&quot; [wikipedia:Communication]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:39:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>communicating</oboInOwl:hasExactSynonym>
         <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">signal exchange</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10323,8 +10334,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000613">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
         <obo:IAO_0000115>&quot;Communication behavior related to the process of conveying meaning in the form of non-word messages through for example gesture, body language or posture; facial expression and eye contact etc.&quot; [wikipedia:.wikipedia.org/wiki/Nonverbal_communication]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:40:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>non-verbal communication behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>nonverbal communication behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10338,8 +10349,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000614">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
         <obo:IAO_0000115>&quot;Communication behavior related to the conveyance of ideas and information through creation of visual representations.&quot; [wikipedia:Visual_communication]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:42:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual communication behavior</rdfs:label>
     </owl:Class>
@@ -10351,8 +10362,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000615">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
         <obo:IAO_0000115>&quot;Communication behavior related to the process of conveying meaning in the form of word messages.&quot; [wikipedia:Oral_communication#Oral_communication]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:44:04Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oral communication behavior</rdfs:label>
     </owl:Class>
@@ -10364,8 +10375,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000616">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000613"/>
         <obo:IAO_0000115>&quot;A nonverbal communication behavior that is characterised by the meeting the eyes between two individuals.&quot; [wikipedia:Eye_contact]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:46:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eye contact</rdfs:label>
     </owl:Class>
@@ -10376,8 +10387,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000617">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:51:05Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">laughing behavior</rdfs:label>
     </owl:Class>
@@ -10389,8 +10400,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000618">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <obo:IAO_0000115>&quot;The behavior in which an organism sheds tears, often accompanied by non-verbal vocalizations and in response to external or internal stimuli.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:52:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>crying behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0060273</oboInOwl:xref>
@@ -10404,8 +10415,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000619">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000293"/>
         <obo:IAO_0000115>&quot;Behavior stemming from understanding of a specific cause and effect in a specific context.&quot; [wikipedia:Insight]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T04:57:19Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavior stemming from insight</rdfs:label>
     </owl:Class>
@@ -10417,8 +10428,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000620">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
         <obo:IAO_0000115>&quot;An emotional behavior that arises from the perceived resistance to the fulfillment of individual will.&quot; [wikipedia:Frustration]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T05:00:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frustration behavior</rdfs:label>
     </owl:Class>
@@ -10430,8 +10441,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000621">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000564"/>
         <obo:IAO_0000115>&quot;A communication disorder in which a person, most often a child, who is normally capable of speech is unable to speak in given situations, or to specific people.&quot; [wikipedia:Selective_mutism]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T05:06:03Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002300</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">selective mutism</rdfs:label>
@@ -10444,8 +10455,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000622">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000567"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any highly repetitive behavior, where the repetition is unusual, difficult to disrupt, and neither the behavior nor repetition serve an obvious function [NBO:AC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T05:18:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0008758</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">stereotypic motor behavior</rdfs:label>
@@ -10458,8 +10469,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000623">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000567"/>
         <obo:IAO_0000115>&quot;Stereotypic behavior characterised by a tendency to repeat vocalizations.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-14T05:20:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0010529</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">echolalia</rdfs:label>
@@ -10472,8 +10483,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000624">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
         <obo:IAO_0000115>&quot;Play behavior associated with the manipulation of objects.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T10:51:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Object play is important in developing skills important in adulthood, especially hunting.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">object play</rdfs:label>
@@ -10486,8 +10497,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000626">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
         <obo:IAO_0000115>&quot;Behavior associated with interactions which resemble sexual behavior but do not lead to copulation.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Sex%20Play.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T10:52:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>love play</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual play</rdfs:label>
@@ -10500,8 +10511,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000627">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
         <obo:IAO_0000115>&quot;Play behavior associated to fighting simulation, although fighting is much slower and gentler with no intention of actual hurt.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Play%20Fighting.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T10:53:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Play fighting helps learning to evaluate oneself and an opponent. This skill is crucial for serious adult situations. Being able to size up an opponent quickly is very important in knowing when to give up or fight for a resource (food, mate, territory, etc. ). Play fighting is one of the most important categories of play because it prepares animals for actual fighting.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">play fight</rdfs:label>
@@ -10514,8 +10525,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000628">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
         <obo:IAO_0000115>&quot;Play behavior that is associated with the pursuit of an individual.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T10:54:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">play chasing</rdfs:label>
     </owl:Class>
@@ -10527,8 +10538,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000629">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000049"/>
         <obo:IAO_0000115>&quot;Play behavior associated with the exhibition of parenting behavior by non-parents.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T11:03:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nursing play</rdfs:label>
     </owl:Class>
@@ -10540,8 +10551,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000630">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000075"/>
         <obo:IAO_0000115>&quot;Play behavior related to the copying the actions of another.&quot; [web:http\://www.bio.davidson.edu/people/vecase/behavior/Spring2009/Sacco/Pages/Imitative%20Play.html]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T11:07:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Imitative play is an excellent means of learning how to perform a task that an adult has perfected. Therefore, imitative play is one of the best ways for animals to learn from the adults in the group.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">imitative play</rdfs:label>
@@ -10555,8 +10566,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000087"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000741"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Harassment of and-or attack of a presumed predator or intruder by multiple individuals at once [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T01:44:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym xml:lang="en">mobbing</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mobbing behavior</rdfs:label>
@@ -10570,8 +10581,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000036"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000631"/>
         <obo:IAO_0000115>&quot;Behavior associated with signals made by the mobbing species while harassing a predator.&quot; [wikipedia:Mobbing_(animal_behavior)]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T01:46:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mobbing calling</rdfs:label>
     </owl:Class>
@@ -10583,8 +10594,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000633">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
         <obo:IAO_0000115>&quot;Aggressive behavior related to the defence of a fixed area against intruders, typically conspecifics.&quot; [GOC:hjd]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T02:02:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>territorial aggression</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>territorial aggressive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10616,8 +10627,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000128"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T02:05:35Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">irritable aggressive behavior</rdfs:label>
     </owl:Class>
@@ -10629,8 +10640,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000635">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000233"/>
         <obo:IAO_0000115>&quot;Behavior related to the activity seen in animals exposed to adverse stimuli, in which the tendency to act defensively is stronger than the tendency to attack.&quot; [web:http\://www.britannica.com/EBchecked/topic/45916/avoidance-behavior]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T03:36:00Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">avoidance behavior</rdfs:label>
     </owl:Class>
@@ -10642,8 +10653,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000636">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000635"/>
         <obo:IAO_0000115>&quot;Behavior related to the activity seen in animals exposed to potential danger in which they exhibit the tendency to act defensively.&quot; [NBO:SD]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-19T03:49:55Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>defense</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>defensive behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10657,8 +10668,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000637">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
         <obo:IAO_0000115>&quot;The actions or reactions of a male, for the purpose of attracting a sexual partner.&quot; [GOC:bf]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-21T08:40:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>male courtship behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0008049</oboInOwl:xref>
@@ -10672,8 +10683,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000638">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000077"/>
         <obo:IAO_0000115>&quot;The actions or reactions of a female, for the purpose of attracting a sexual partner.&quot; [GOC:bf]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-21T08:42:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>female courtship behaviour</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0008050</oboInOwl:xref>
@@ -10687,8 +10698,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000639">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000234"/>
         <obo:IAO_0000115>&quot;Any process which modulates the physical craving for water over long term water deprivation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-21T09:06:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">long term thirst regulation</rdfs:label>
     </owl:Class>
@@ -10700,8 +10711,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000640">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000234"/>
         <obo:IAO_0000115>&quot;Any process which modulates the physical craving for water over short term water deprivation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-04-21T09:06:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short term thirst regulation</rdfs:label>
     </owl:Class>
@@ -10712,8 +10723,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000641">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000171"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-06T03:56:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">discrimination learning</rdfs:label>
     </owl:Class>
@@ -10725,8 +10736,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000642">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
         <obo:IAO_0000115>&quot;Two or more unprovoked recurrent seizures.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T11:42:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>unprovoked seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0001275</oboInOwl:xref>
@@ -10756,8 +10767,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000568"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to movements that occur independent of planning.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T11:56:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">involuntary movement behavior phenotype</rdfs:label>
     </owl:Class>
@@ -10785,8 +10796,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000568"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to movements executed with intent.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T11:57:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">voluntary movement behavior phenotype</rdfs:label>
     </owl:Class>
@@ -10798,8 +10809,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000645">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
         <obo:IAO_0000115>&quot;A rapid and repeated body muscle contract that results in an uncontrolled shaking of the body.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T11:59:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>fit</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">convulsion</rdfs:label>
@@ -10812,8 +10823,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000646">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
         <obo:IAO_0000115>&quot;A seizure which affect only a part of the brain at onset.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Focal_seizures]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T12:49:09Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>focal seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>localized seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10829,8 +10840,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000647">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
         <obo:IAO_0000115>&quot;A partial seizure which affect only a small region of the brain, often the temporal lobes and/or hippocampi whilst consciousness is unaffected.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Simple_partial_seizure]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T12:51:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002349</oboInOwl:xref>
         <rdfs:comment>Depending on the area of cerebral cortex involved, symptoms may be motor, cognitive, sensory, autonomic, or affective. Consciousness is not impaired.</rdfs:comment>
@@ -10844,8 +10855,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000648">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
         <obo:IAO_0000115>&quot;A seizure that is associated with bilateral cerebral hemisphere involvement and causes impairment of awareness or responsiveness, i.e. loss of consciousness.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Complex_partial_seizures]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T12:59:01Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>psychomotor seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>temporal lobe seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10860,8 +10871,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000649">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000065"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T01:51:38Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">being conscious</rdfs:label>
     </owl:Class>
@@ -10873,8 +10884,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000650">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of focal epilepsy characterized by recurrent seizures.&quot; [NBO:http\://en.wikipedia.org/wiki/Temporal_lobe_epilepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T02:42:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>psychomotor epilepsy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">temporal lobe epilepsy</rdfs:label>
@@ -10887,8 +10898,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000651">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
         <obo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T02:50:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>focal clonic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>motor seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10903,8 +10914,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000652">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
         <obo:IAO_0000115>&quot;A simple partial seizure affecting any of the five senses -- vision, touch, smell, taste, and hearing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T02:51:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Jacksonian sensory seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>sensory seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10919,8 +10930,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000653">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
         <obo:IAO_0000115>&quot;A simple partial seizure affecting the part of the nervous system that automatically controls bodily functions.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T02:51:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>abdominal epilepsy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>autonomic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -10935,8 +10946,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000654">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
         <obo:IAO_0000115>&quot;A simple partial seizure affecting the emotional behavior.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T02:51:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>psychic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>simple partial seizures of temporal lobe origin</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>temporal lobe auras</oboInOwl:hasExactSynonym>
@@ -10968,8 +10979,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related any of the five senses -- vision, touch, smell, taste, and hearing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:06:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sensation behavior phenotype</rdfs:label>
     </owl:Class>
@@ -10997,8 +11008,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
         <obo:IAO_0000115>&quot;A phenotype manifested by a behavior related to the sensations arising from the skin and from the muscles, tendons, and joints.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:20:39Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">somatic sensation related behavior phenotype</rdfs:label>
     </owl:Class>
@@ -11025,8 +11036,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000656"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:21:20Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cutaneous sensation behavior phenotype</rdfs:label>
     </owl:Class>
@@ -11054,8 +11065,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or reactions of an organism in response to a sound.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:22:16Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">auditory behavior phenotype</rdfs:label>
     </owl:Class>
@@ -11084,8 +11095,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
         <obo:IAO_0000115>&quot;A phenotype manifested by a behavior related to the actions or reactions of an organism in response to a visual stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:22:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">visual behavior phenotype</rdfs:label>
     </owl:Class>
@@ -11113,8 +11124,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000655"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the sensation of chemicals.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:26:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemosensory behavior phenotype</rdfs:label>
     </owl:Class>
@@ -11142,8 +11153,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000660"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the sensation of odors.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:28:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">olfactory behavior phenotype</rdfs:label>
     </owl:Class>
@@ -11155,8 +11166,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000662">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
         <obo:IAO_0000115>&quot;A seizure which affect the whole of the brain at onset.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:46:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>primarily generalized seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002197</oboInOwl:xref>
@@ -11170,8 +11181,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000663">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:49:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0007334</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">partial seizure evolving to secondarily generalized seizure</rdfs:label>
@@ -11183,8 +11194,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000664">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000663"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:50:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure evolving to generalized seizure</rdfs:label>
     </owl:Class>
@@ -11195,8 +11206,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000665">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000663"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:50:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex partial seizure evolving to generalized seizure</rdfs:label>
     </owl:Class>
@@ -11207,8 +11218,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000666">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000663"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:50:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial seizure evolving to complex partial seizure evolving to generalized seizure</rdfs:label>
     </owl:Class>
@@ -11219,8 +11230,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000667">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000648"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:51:50Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial onset, followed by impairment of consciousness</rdfs:label>
     </owl:Class>
@@ -11231,8 +11242,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000668">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000648"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:52:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">with impairment of consciousness at onset</rdfs:label>
     </owl:Class>
@@ -11244,8 +11255,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000669">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
         <obo:IAO_0000115>&quot;An absence seizure is a brief (usually less that 20 seconds), generalized epileptic seizure of sudden onset and termination.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Absence_seizure]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:54:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>petit mal seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002121</oboInOwl:xref>
@@ -11260,8 +11271,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000670">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
         <obo:IAO_0000115>&quot;A type of generalized seizure that consist of a brief lapse in muscle tone that are caused by temporary alterations in brain function.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Atonic_seizure]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T03:57:35Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>akinetic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>drop attack</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>drop seizure</oboInOwl:hasExactSynonym>
@@ -11277,8 +11288,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000671">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
         <obo:IAO_0000115>&quot;A type of seizure that is characterised by a very brief symmetric alternating contraction and relaxation of a muscle or a group of muscles.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T04:52:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>myoclonus</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0001336</oboInOwl:xref>
@@ -11295,8 +11306,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000672">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
         <obo:IAO_0000115>&quot;A type of seizure that is characterised by rhythmic symmetric alternating contraction and relaxation of a muscle or a group of muscles.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T04:54:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>MP:0003996</oboInOwl:xref>
         <rdfs:comment>Rapid, repetitive motor activity.</rdfs:comment>
@@ -11310,8 +11321,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000673">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000688"/>
         <obo:IAO_0000115>&quot;A type of epilepsy characterised by myoclonic seizures usually involving the neck, shoulders, and upper arms.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T04:55:32Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Janz syndrome</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">juvenile myoclonic epilepsy</rdfs:label>
@@ -11324,8 +11335,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000674">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of epilepsy characterised by multiple different types of seizures, particularly including tonic (stiffening) and atonic (drop) types of seizures.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T04:56:28Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lennox-Gastaut syndrome</rdfs:label>
     </owl:Class>
@@ -11337,8 +11348,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000675">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure generated by sudden sensor stimulation caused by the environment.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T11:07:41Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>environmental epilepsy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>reflex epilepsy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -11353,8 +11364,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000676">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
         <obo:IAO_0000115>&quot;A type of generalized seizure characterised by a combination of tonic stiffening (extensions) followed by clonic flexion motions.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:03:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>gran mal seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>grand mal seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -11371,8 +11382,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000677">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
         <obo:IAO_0000115>&quot;A type of seizure characterised by muscle rigidity.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:09:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0010818</oboInOwl:xref>
         <oboInOwl:xref>MP:0002826</oboInOwl:xref>
@@ -11386,8 +11397,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000678">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure associated with a significant rise in body temperature.&quot; [wikpedia:http\://en.wikipedia.org/wiki/Febrile_seizure]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:13:26Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>febrile convulsion</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>fever fit</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -11402,8 +11413,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000679">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000678"/>
         <obo:IAO_0000115>&quot;A febrile seizure that lasts less than 15 minutes , does not recur in 24 hours, and involves the entire body.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Febrile_seizure]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:16:07Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple febrile seizure</rdfs:label>
     </owl:Class>
@@ -11415,8 +11426,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000680">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000678"/>
         <obo:IAO_0000115>&quot;A febrile seizure characterized by longer duration, recurrence, or focus on only part of the body.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Febrile_seizure]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:19:54Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex febrile seizure</rdfs:label>
     </owl:Class>
@@ -11428,8 +11439,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000681">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;Benign rolandic epilepsy is characterized by either simple partial seizures involving the mouth and face or generalized tonic-clonic seizures.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Rolandic_epilepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:24:49Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>benign (childhood) epilepsy with centrotemporal (EEG) spikes</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">benign rolandic epilepsy</rdfs:label>
@@ -11442,8 +11453,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000682">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000650"/>
         <obo:IAO_0000115>&quot;A temporal lobe epilepsy arises in the hippocampus, parahippocampal gyrus and amygdala which are located in the inner aspect of the temporal lobe.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Temporal_lobe_epilepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:30:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>MTLE</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">medial temporal lobe epilepsy</rdfs:label>
@@ -11456,8 +11467,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000683">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000650"/>
         <obo:IAO_0000115>&quot;A temporal lobe epilepsy arises in the neocortex on the outer surface of the temporal lobe of the brain.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Temporal_lobe_epilepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:31:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>LTLE</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lateral temporal lobe epilepsy</rdfs:label>
@@ -11469,8 +11480,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000684">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:32:59Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>pyknolepsy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">childhood absence epilepsy</rdfs:label>
@@ -11482,8 +11493,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000685">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:39:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">continuous seizure</rdfs:label>
     </owl:Class>
@@ -11495,8 +11506,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000686">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
         <obo:IAO_0000115>&quot;Paroxysmal events that mimic an epileptic seizure but do not involve abnormal, rhythmic discharges of cortical neurons.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Non-epileptic_seizure]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:47:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>non-epileptic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">provoked seizure</rdfs:label>
@@ -11509,8 +11520,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000687">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure of psychological origin that superficially resembles an epileptic seizure, but without the characteristic electrical discharges associated with epilepsy.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Psychogenic_non-epileptic_seizures]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:50:08Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>PNES</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>non-epileptic attack disorder</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -11524,8 +11535,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000688">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of epilepsy that is characterised by myoclonic seizures.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:53:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myoclonic epilepsy</rdfs:label>
     </owl:Class>
@@ -11537,8 +11548,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000689">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000688"/>
         <obo:IAO_0000115>&quot;A myoclonic epilepsy characterised by a combination of myoclonic and tonic-clonic seizures.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Progressive_myoclonic_epilepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:55:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">progressive myoclonic epilepsy</rdfs:label>
     </owl:Class>
@@ -11550,8 +11561,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000690">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;Continuous unremitting seizure lasting longer than 30 minutes or recurrent seizures without regaining consciousness between seizures for greater than 30 minutes.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Status_epilepticus]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T05:59:47Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002133</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">status epilepticus</rdfs:label>
@@ -11563,8 +11574,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000691">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T06:42:06Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-convulsive status epilepticus</rdfs:label>
     </owl:Class>
@@ -11575,8 +11586,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000692">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T06:42:29Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">generalised convulsive status epilepticus</rdfs:label>
     </owl:Class>
@@ -11588,8 +11599,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000693">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000691"/>
         <obo:IAO_0000115>&quot;A convulsive status epilepticus characterized by seizures involving long-lasting stupor, staring and unresponsiveness.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Complex_partial_status_epilepticus]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T07:20:21Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex partial status epilepticus</rdfs:label>
     </owl:Class>
@@ -11600,8 +11611,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000694">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000691"/>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-27T07:21:27Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">absence status epilepticus</rdfs:label>
     </owl:Class>
@@ -11613,8 +11624,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000695">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
         <obo:IAO_0000115>&quot;Subtle  status epilepticus consists of electrical seizure activity in the brain that endures when the associated motor responses are fragmentary or even absent.&quot; [web:http\://emedicine.medscape.com/article/1164462-overview]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T10:08:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">subtle status epilepticus</rdfs:label>
     </owl:Class>
@@ -11626,8 +11637,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000696">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000690"/>
         <obo:IAO_0000115>&quot;Simple partial SE consists of seizures that are localized to a discrete area of cerebral cortex and produce no alteration in consciousness.&quot; [web:http\://emedicine.medscape.com/article/1164462-overview]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T10:10:13Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">simple partial status epilepticus</rdfs:label>
     </owl:Class>
@@ -11639,8 +11650,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000697">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of epilepsy characterized by brief, recurring seizures that arise in the frontal lobes of the brain, often while the patient is sleeping.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Frontal_lobe_epilepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T10:14:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">frontal lobe epilepsy</rdfs:label>
     </owl:Class>
@@ -11652,8 +11663,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000698">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of epilepsy characterised by seizure, usually tonic clonic, that occur only during sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T10:17:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nocturnal epilepsy</rdfs:label>
     </owl:Class>
@@ -11665,8 +11676,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000699">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000675"/>
         <obo:IAO_0000115>&quot;A type of reflex seizure caused by visual stimuli that form patterns in time or space, such as flashing lights, bold, regular patterns, or regular moving patterns.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Photosensitive_epilepsy]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T11:11:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>photosensitive epilepsy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">photosensitive seizure</rdfs:label>
@@ -11679,8 +11690,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000700">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000675"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by exposure to an auditory stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T11:12:23Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasAlternativeId>NBO:0000725</oboInOwl:hasAlternativeId>
         <oboInOwl:hasExactSynonym>auditory stimulation induced seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
@@ -11695,8 +11706,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000701">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000669"/>
         <obo:IAO_0000115>&quot;An absence seizure induced by hyperventilation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T11:59:14Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">typical absence seizure</rdfs:label>
     </owl:Class>
@@ -11708,8 +11719,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000702">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000669"/>
         <obo:IAO_0000115>&quot;An absence seizure not induced by hyperventilation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T11:59:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0007270</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atypical absence seizure</rdfs:label>
@@ -11722,8 +11733,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000703">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
         <obo:IAO_0000115>&quot;A generalized seizure that was initiated as a partial seizure.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:08:24Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002434</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secondary generalized seizure</rdfs:label>
@@ -11736,8 +11747,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000704">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000703"/>
         <obo:IAO_0000115>&quot;A generalized seizure that was initiated as a partial seizure but very rapidly spread to both hemispheres.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:11:05Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rapid secondary generalization</rdfs:label>
     </owl:Class>
@@ -11749,8 +11760,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000705">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000643"/>
         <obo:IAO_0000115>&quot;Purposeless repetitive motor activities that often occur during a seizure.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:14:35Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:comment>Automatisms may occur during complex partial or absence seizures.</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">automatism</rdfs:label>
@@ -11763,8 +11774,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000706">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000705"/>
         <obo:IAO_0000115>&quot;An automatism characterised by involuntary oral activity such as lip smacking and swallowing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:15:48Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">oral automatism</rdfs:label>
     </owl:Class>
@@ -11776,8 +11787,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000707">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000705"/>
         <obo:IAO_0000115>&quot;An automatism characterised by involuntary movement of the limbs or body such as  fumbling, picking and rubbing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:17:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gestural automatism</rdfs:label>
     </owl:Class>
@@ -11789,8 +11800,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000708">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000705"/>
         <obo:IAO_0000115>&quot;An automatism characterised by stereotyped series of motor actions usually involving the limbs bilaterally such as swimming \nmovements, kicking movements and bicycling movements.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:20:03Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">complex motor automatism</rdfs:label>
     </owl:Class>
@@ -11802,8 +11813,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000709">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of a drug.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:32:11Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drug induced seizure</rdfs:label>
     </owl:Class>
@@ -11815,8 +11826,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000710">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000709"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by accidental or intentional ingestion or application of a drug in quantities greater than recommended.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:34:37Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drug overdose induced seizure</rdfs:label>
     </owl:Class>
@@ -11828,8 +11839,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000711">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000709"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by termination of drug administration.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:35:22Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drug withdrawal induced seizure</rdfs:label>
     </owl:Class>
@@ -11841,8 +11852,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000712">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood glucose levels.&quot; [GVG:NBO]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:35:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002173</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypoglycemia induced seizure</rdfs:label>
@@ -11855,8 +11866,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000713">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of cocaine.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:36:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cocaine overdose induced seizure</rdfs:label>
     </owl:Class>
@@ -11868,8 +11879,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000714">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of isoniazide.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:36:46Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">isoniazide overdose induced seizure</rdfs:label>
     </owl:Class>
@@ -11881,8 +11892,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000715">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of amphetamine.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T12:37:01Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">amphetamine overdose induced seizure</rdfs:label>
     </owl:Class>
@@ -11894,8 +11905,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000716">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of antidepressant.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:14:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">antidepressant overdose induced seizure</rdfs:label>
     </owl:Class>
@@ -11907,8 +11918,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000717">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of theophylline.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:15:33Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">theophylline overdose induced seizure</rdfs:label>
     </owl:Class>
@@ -11920,8 +11931,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000718">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000710"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of penicillin.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:16:56Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">penicillin overdose induced seizure</rdfs:label>
     </owl:Class>
@@ -11933,8 +11944,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000719">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by termination of alcohol administration.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:19:06Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">alcohol withdrawal induced seizure</rdfs:label>
     </owl:Class>
@@ -11946,8 +11957,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000720">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by termination of benzodiazepine administration.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:22:57Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">benzodiazepine withdrawal induced seizure</rdfs:label>
     </owl:Class>
@@ -11959,8 +11970,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000721">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by termination of barbiturates administration.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:24:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">barbiturates withdrawal induced seizure</rdfs:label>
     </owl:Class>
@@ -11972,8 +11983,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000722">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000711"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by termination of heroin administration.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:26:05Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">heroin withdrawal induced seizure</rdfs:label>
     </owl:Class>
@@ -11985,8 +11996,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000723">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood magnesium levels.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:34:40Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypomagnesemia induced seizure</rdfs:label>
     </owl:Class>
@@ -11998,8 +12009,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000724">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by exposure to an electrical stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T01:42:36Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electrical stimulation induced seizure</rdfs:label>
     </owl:Class>
@@ -12011,8 +12022,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000726">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by the administration of a brain trauma.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T03:39:02Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trauma induced seizure</rdfs:label>
     </owl:Class>
@@ -12024,8 +12035,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000727">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of seizure invoking stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T03:46:52Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">kindling induced seizure</rdfs:label>
     </owl:Class>
@@ -12037,8 +12048,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000728">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000727"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of electrical stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T03:50:30Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electrical kindling induced seizure</rdfs:label>
     </owl:Class>
@@ -12050,8 +12061,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000729">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000727"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of chemical stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T03:51:25Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chemical kindling induced seizure</rdfs:label>
     </owl:Class>
@@ -12063,8 +12074,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000730">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000727"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by kindling, a repeated administration of auditory stimulus which eventually results changes in the brain.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T03:52:15Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">auditory kindling induced seizure</rdfs:label>
     </owl:Class>
@@ -12076,8 +12087,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000731">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000651"/>
         <obo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior of one side of the body.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T05:51:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>unilateral clonic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0006813</oboInOwl:xref>
@@ -12091,8 +12102,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000732">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000731"/>
         <obo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior of left side of the body.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T06:01:58Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">left side clonic seizure</rdfs:label>
     </owl:Class>
@@ -12104,8 +12115,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000733">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000731"/>
         <obo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior of right side of the body.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T06:03:17Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">right side clonic seizure</rdfs:label>
     </owl:Class>
@@ -12118,8 +12129,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000588"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of epileptic seizures occurring in infants and characterised by clusters of myoclonic spasms.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T06:47:31Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>Generalized Flexion Epilepsy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Infantile Epileptic Encephalopathy</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym>Infantile Myoclonic Encephalopathy</oboInOwl:hasExactSynonym>
@@ -12140,8 +12151,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000735">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood calcium levels.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T08:04:53Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002199</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hypocalcemia induced seizure</rdfs:label>
@@ -12154,8 +12165,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000736">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000703"/>
         <obo:IAO_0000115>&quot;A generalized tonic clonic seizure that was initiated as a partial seizure.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T08:28:12Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0002602</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">secondary generalized tonic clonic seizure</rdfs:label>
@@ -12168,8 +12179,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000737">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
         <obo:IAO_0000115>&quot;A type of seizure induced by exposure to a light stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T08:34:10Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0001327</oboInOwl:xref>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">photostimulation induced seizure</rdfs:label>
@@ -12182,8 +12193,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000738">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of epilepsy that is characterised a sudden burst of energy, usually in the form of laughing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T11:12:42Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>gelastic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0010821</oboInOwl:xref>
@@ -12197,8 +12208,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000739">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
         <obo:IAO_0000115>&quot;A type of epilepsy that is characterised a sudden paroxysmal crying.&quot; [NBO:&lt;new dbxref&gt;, NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <dc:date>2011-05-28T11:18:45Z</dc:date>
+        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasExactSynonym>dacrystic seizure</oboInOwl:hasExactSynonym>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>HP:0010820</oboInOwl:xref>
@@ -12211,8 +12222,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000740">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000015"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-02-16T01:16:13Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior by intent</rdfs:label>
     </owl:Class>
@@ -12223,8 +12234,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000741">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000015"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-02-16T01:16:31Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aggressive behavior by means</rdfs:label>
     </owl:Class>
@@ -12236,8 +12247,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000742">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
         <obo:IAO_0000115>&quot;Agressive behavior towards oneself.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-02-16T01:16:55Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">autoaggressive behavior</rdfs:label>
     </owl:Class>
@@ -12250,8 +12261,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000105"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000121"/>
         <obo:IAO_0000115>&quot;An aggressive behavior towards other members of the society.&quot; [NBO:RH]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-02-16T02:27:08Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">social aggression behavior</rdfs:label>
     </owl:Class>
@@ -12262,8 +12273,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000744">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-16T04:51:23Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perception behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12275,8 +12286,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000745">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000612"/>
         <obo:IAO_0000115>&quot;A social behavior related to the activity of conveying information by means of a system of arbitrary signals, such as voice sounds, gestures, or written symbols.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-16T05:13:17Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">language communication behavior</rdfs:label>
     </owl:Class>
@@ -12304,8 +12315,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/PATO_0000117"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-16T05:57:42Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spatial perception</rdfs:label>
     </owl:Class>
@@ -12316,8 +12327,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000747">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000007"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-17T09:51:17Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">jaw movement</rdfs:label>
     </owl:Class>
@@ -12329,8 +12340,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000748">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000007"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The act of displacing part or all of the tongue from its current position [NBO:SMAC]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-17T09:52:25Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tongue movement</rdfs:label>
     </owl:Class>
@@ -12341,8 +12352,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000749">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000750"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-17T09:53:29Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">blinking</rdfs:label>
     </owl:Class>
@@ -12353,8 +12364,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000750">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000001"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-17T09:54:30Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eyelid movement</rdfs:label>
     </owl:Class>
@@ -12365,8 +12376,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000751">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000308"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-16T05:23:06Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">perception behavior by means</rdfs:label>
     </owl:Class>
@@ -12394,8 +12405,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0050967"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-17T03:59:12Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">electrical nociceptive behavior</rdfs:label>
     </owl:Class>
@@ -12424,8 +12435,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000474"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to all sleep stages in the circadian sleep/wake cycle other than REM sleep.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T10:59:20Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">non-rapid eye movement sleep behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12454,8 +12465,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000419"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000474"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the stage in the circadian sleep cycle during which dreams occur and the body undergoes marked changes including rapid eye movement, loss of reflexes, and increased pulse rate and brain activity.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T11:08:01Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rapid eye movement sleep phenotype</rdfs:label>
     </owl:Class>
@@ -12483,8 +12494,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or interactions of an organism that are associated with reproduction.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:08:56Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reproductive behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12512,8 +12523,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the interactions between organisms for the purpose of mating.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:10:16Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mating behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12541,8 +12552,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the specific actions or reactions of an organism following mating.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:10:27Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">post-mating behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12570,8 +12581,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000755"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:10:54Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sexual activity phenotype</rdfs:label>
     </owl:Class>
@@ -12599,8 +12610,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000756"/>
         <obo:IAO_0000115>&quot;Observable characteristic related to the behavioral interactions between organisms for the purpose of attracting sexual partners.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:13:54Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">courtship behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12628,8 +12639,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000759"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or reactions of a female, for the purpose of attracting a sexual partner.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:16:31Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female courtship behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12657,8 +12668,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000759"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the actions or reactions of a male, for the purpose of attracting a sexual partner.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:16:49Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male courtship behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12686,8 +12697,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000758"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the act of sexual union between male and female, involving the transfer of sperm.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:22:41Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">copulation phenotype</rdfs:label>
     </owl:Class>
@@ -12715,8 +12726,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000758"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the female activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:22:53Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">female sexual activity phenotype</rdfs:label>
     </owl:Class>
@@ -12744,8 +12755,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000758"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behavior related to the male activity which primary purpose is the sexual reproduction.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:23:03Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">male sexual activity phenotype</rdfs:label>
     </owl:Class>
@@ -12773,8 +12784,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000266"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to the acquisition and processing of information and/or the storage and retrieval of this information over time.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:33:56Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">learning and/or memory behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12802,8 +12813,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000765"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour associated with any process in an organism in which a relatively long-lasting adaptive behavioral change occurs as the result of experience.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:34:12Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">learning behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12831,8 +12842,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000765"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to the ability of an organism&apos;s ability to store, retain, and recall information and experiences.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T02:34:26Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">memory behavior behavior</rdfs:label>
     </owl:Class>
@@ -12859,8 +12870,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T03:46:31Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emission behavior phenotype</rdfs:label>
     </owl:Class>
@@ -12888,8 +12899,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000768"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to the elimination by an organism of the waste products that arise as a result of metabolic activity. These products include water, carbon dioxide (CO2), and nitrogenous compounds.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T03:46:55Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of excretion phenotype</rdfs:label>
     </owl:Class>
@@ -12917,8 +12928,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000769"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to the expulsion of feces from the rectum.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T03:47:09Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of defecation phenotype</rdfs:label>
     </owl:Class>
@@ -12946,8 +12957,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000769"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to the regulation of body fluids process by which parasympathetic nerves stimulate the bladder wall muscle to contract and expel urine from the body.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-19T03:48:16Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of urination phenotype</rdfs:label>
     </owl:Class>
@@ -12974,8 +12985,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000768"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-20T05:24:59Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of production of sound phenotype</rdfs:label>
     </owl:Class>
@@ -13002,8 +13013,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000768"/>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-20T05:25:03Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of external secretion phenotype</rdfs:label>
     </owl:Class>
@@ -13031,8 +13042,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000773"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour related to the regulated release of the aqueous layer of the tear film from the lacrimal glands.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-20T05:28:58Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">behavioral control of lacrimation phenotype</rdfs:label>
     </owl:Class>
@@ -13061,8 +13072,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000772"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour in which an organism sheds tears, often accompanied by non-verbal vocalizations and in response to external or internal stimuli.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-20T05:30:38Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">crying behavior phenotype</rdfs:label>
     </owl:Class>
@@ -13091,8 +13102,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000601"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000772"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour associated with signals made by the mobbing species while harassing a predator.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-20T05:32:31Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mobbing calling phenotype</rdfs:label>
     </owl:Class>
@@ -13120,8 +13131,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000772"/>
         <obo:IAO_0000115>&quot;Observable characteristic of behaviour in which an organism produces sounds by a mechanism involving its respiratory system.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-20T05:34:04Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">vocalization behavior phenotype</rdfs:label>
     </owl:Class>
@@ -13149,8 +13160,8 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NBO_0000003"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <dc:date>2012-03-23T10:05:56Z</dc:date>
+        <oboInOwl:created_by>gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">emotional conditioning</rdfs:label>
     </owl:Class>
@@ -14171,9 +14182,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000089"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0015003"/>
         <obo:IAO_0000115>A predator behavior involving actively stalking prey over a distance.</obo:IAO_0000115>
-        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-03-11T13:51:02Z</dc:date>
+        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <rdfs:label xml:lang="en">hunting behavior</rdfs:label>
     </owl:Class>
     
@@ -14184,9 +14195,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015000">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000089"/>
         <obo:IAO_0000115>A predator behavior involving a surprise attack on unsuspecting prey. The predator remains in one place and waits for prey to come near. The predator conceals itself and then subdues its prey with its own body or body parts.</obo:IAO_0000115>
-        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-03-11T13:51:02Z</dc:date>
+        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <rdfs:label xml:lang="en">ambush behavior</rdfs:label>
     </owl:Class>
     
@@ -14197,9 +14208,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000635"/>
         <obo:IAO_0000115>An avoidance behavior engaged in by prey that reduces the success of a predator without the prey actually attacking the predator.</obo:IAO_0000115>
-        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-03-11T13:51:02Z</dc:date>
+        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <rdfs:label xml:lang="en">predator avoidance behavior</rdfs:label>
     </owl:Class>
     
@@ -14210,9 +14221,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015002">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000089"/>
         <obo:IAO_0000115>A predator behavior involving subduing prey using a structure or modification of the environment created by the predator for that purpose.</obo:IAO_0000115>
-        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-03-11T13:51:02Z</dc:date>
+        <oboInOwl:created_by>Nicolas Matentzoglu</oboInOwl:created_by>
         <rdfs:label xml:lang="en">trapping behavior</rdfs:label>
     </owl:Class>
     
@@ -14223,9 +14234,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015003">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
         <obo:IAO_0000115>Feeding behavior during which a living entity acquires food and energy by actively searching for food resources.</obo:IAO_0000115>
-        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-08-04T13:51:02Z</dc:date>
+        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <rdfs:label xml:lang="en">active foraging behavior</rdfs:label>
     </owl:Class>
     
@@ -14236,9 +14247,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015004">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
         <obo:IAO_0000115>Feeding behavior during which a living entity acquires food and energy by actively searching for food resources.</obo:IAO_0000115>
-        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-08-04T13:51:02Z</dc:date>
+        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <rdfs:label xml:lang="en">active foraging behavior</rdfs:label>
     </owl:Class>
     
@@ -14249,9 +14260,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015005">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
         <obo:IAO_0000115>Consumption behavior that involves inhaling a material (such as finely ground tobacco leaves) through the nose.</obo:IAO_0000115>
-        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-09-06T10:51:02Z</dc:date>
+        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <rdfs:label xml:lang="en">smoking behavior</rdfs:label>
     </owl:Class>
     
@@ -14262,9 +14273,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015006">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0015005"/>
         <obo:IAO_0000115>Smoking behavior that involves burning a substance such as tobacco and tasting or inhaling the smoke through a pipe.</obo:IAO_0000115>
-        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-09-06T10:51:02Z</dc:date>
+        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <rdfs:label xml:lang="en">pipe smoking behavior</rdfs:label>
     </owl:Class>
     
@@ -14275,9 +14286,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015007">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0015005"/>
         <obo:IAO_0000115>Smoking behavior that involves burning a substance such as tobacco wrapped in paper and inhaling the smoke.</obo:IAO_0000115>
-        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-09-06T10:51:02Z</dc:date>
+        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <rdfs:label xml:lang="en">cigarette smoking behavior</rdfs:label>
     </owl:Class>
     
@@ -14288,9 +14299,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0015005"/>
         <obo:IAO_0000115>Smoking behavior that involves burning a substance such as tobacco wrapped in tobacco leaf and inhaling the smoke.</obo:IAO_0000115>
-        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-09-06T10:51:02Z</dc:date>
+        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <rdfs:label xml:lang="en">cigar smoking behavior</rdfs:label>
     </owl:Class>
     
@@ -14301,9 +14312,9 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0015009">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
         <obo:IAO_0000115>Consumption behavior that involves inhaling a material (such as finely ground tobacco leaves) through the nose.</obo:IAO_0000115>
-        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <dc:contributor>http://orcid.org/0000-0002-2908-3327</dc:contributor>
         <dc:date>2019-09-06T10:51:02Z</dc:date>
+        <oboInOwl:created_by>https://orcid.org/0000-0002-7356-1779</oboInOwl:created_by>
         <rdfs:label xml:lang="en">snuffing behavior</rdfs:label>
     </owl:Class>
     
@@ -15331,14 +15342,119 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     
 
 
+    <!-- http://purl.obolibrary.org/obo/NBO_0045000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
+        <obo:IAO_0000115>Any habitual use of the tobacco plant leaf and its products.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T20:46:57Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <rdfs:label xml:lang="en">tobacco consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0045001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0045000"/>
+        <obo:IAO_0000115>A behavior of chewing a type of smokeless tobacco maked from cured tobacco leaves. Often the tobacco is left in the mouth and chewed but the leaves are not swallowed.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T20:51:17Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <oboInOwl:hasExactSynonym>spit tobacco consumption</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">tobacco chewing behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0045002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045002">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0015005"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0045000"/>
+        <obo:IAO_0000115>The inhalation and exhalation of tobacco smoke.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T20:51:34Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <rdfs:label xml:lang="en">tobacco smoking behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0045003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045003">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0045000"/>
+        <obo:IAO_0000115>The inhalation and exhalation of tobacco aerosol, referred to as vapor, which is produced by an e-cigarette or other device.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T20:51:58Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <rdfs:label xml:lang="en">tobacco vaping behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0045004 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045004">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0001845"/>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T21:03:19Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <rdfs:label xml:lang="en">cannabis consumption</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0045005 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045005">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0015005"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0045004"/>
+        <obo:IAO_0000115>The inhalation and exhalation of marijuana smoke.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T21:04:14Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <oboInOwl:hasExactSynonym>marijuana smoking behavior</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pot smoking behavior</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>weed smoking behavior</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">cannabis smoking behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0045006 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045006">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0045004"/>
+        <obo:IAO_0000115>The inhalation and exhalation of cannabis aerosol, referred to as vapor, which is produced by an e-cigarette or other device.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T21:04:28Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <oboInOwl:hasExactSynonym>marijuana vaping behavior</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>pot vaping behavior</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym>weed vaping behavior</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">cannabis vaping behavior</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/NBO_0045007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0045007">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0045004"/>
+        <obo:IAO_0000115>The consuming of cannabis through eating or applying the oil sublingually.</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-27T21:04:49Z</dc:date>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-7941-2961"/>
+        <oboInOwl:hasExactSynonym>marijuana oil consumption</oboInOwl:hasExactSynonym>
+        <rdfs:label xml:lang="en">cannabis oil consumption</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/NBO_0050000 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0050000">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000079"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A feeding behavior during which an animal ingests biomass produced by a plant or other primary producer</obo:IAO_0000115>
+        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-09-14T19:12:10+09:00</dc:date>
         <oboInOwl:created_by>http://orcid.org/0000-0002-1816-4260</oboInOwl:created_by>
         <oboInOwl:created_by>http://orcid.org/0000-0002-4366-3088</oboInOwl:created_by>
-        <dc:date rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-09-14T19:12:10+09:00</dc:date>
         <oboInOwl:hasDbXref>https://en.wikipedia.org/wiki/Grazing</oboInOwl:hasDbXref>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grazing behaviour</rdfs:label>

--- a/src/ontology/nbo-edit.owl
+++ b/src/ontology/nbo-edit.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://purl.obolibrary.org/obo/nbo.owl/"
-     xml:base="http://purl.obolibrary.org/obo/nbo.owl/"
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/nbo.owl#"
+     xml:base="http://purl.obolibrary.org/obo/nbo.owl"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:go="http://purl.obolibrary.org/obo/go#"
      xmlns:nbo="http://purl.obolibrary.org/obo/nbo.owl#"


### PR DESCRIPTION
Added several terms for cannabis and tobacco consumption. #98 

BUT, I did not add the cigar, cigarette, pipe smoking as children to tobacco smoking because the definitions are such that it can be any substance and not just tobacco.  

It is possible someone may want non-specific terms.  If that is the case, maybe vaping behavior should be added with non-specific consumption of aerosols definition?  Not sure. I
'm probably over thinking this, but I didn't want to alter the terms if they were intentionally  added to not be specific.  @diatomsRcool and @matentzn  could weigh-in.